### PR TITLE
fix(release): Use 'uv tool run twine' for package verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Verify build artifacts
         run: |
           ls -lh dist/
-          uv run twine check dist/*
+          uv tool run twine check dist/*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
## Problem
Release workflow fails with error: `Failed to spawn: twine - No such file or directory`

## Solution  
Replace `uv run twine` with `uv tool run twine` to install and run twine on-demand without adding it to project dependencies.

## Testing
- [x] CI checks pass
- [x] Release workflow completes successfully for tagged commit