### PR TITLE
Hotfix/pydantic 2.11.9 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = [
 dependencies = [
   "httpx>=0.25.0,<1.0.0",
   "python-socketio[asyncio_client]>=5.14.0,<6.0.0",
-  "pydantic>=2.12.2,<3.0.0",
+  "pydantic>=2.11.9,<3.0.0",
   "typing-extensions>=4.15.0,<5.0.0",
   "tree-sitter>=0.21.3",
   "tree-sitter-javascript>=0.21.1",
@@ -67,12 +67,7 @@ packages = ["src/pybragerone"]
 include = ["src/pybragerone/py.typed"]
 
 [tool.hatch.build.targets.sdist]
-include = [
-  "src/pybragerone",
-  "README.rst",
-  "docs/README.rst",
-  "LICENSE",
-]
+include = ["src/pybragerone", "README.rst", "docs/README.rst", "LICENSE"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1664,7 +1664,7 @@ requires-dist = [
     { name = "aiofiles", marker = "extra == 'cli'", specifier = ">=24.1" },
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
     { name = "keyring", marker = "extra == 'keyring'", specifier = ">=25.0.0" },
-    { name = "pydantic", specifier = ">=2.12.2,<3.0.0" },
+    { name = "pydantic", specifier = ">=2.11.9,<3.0.0" },
     { name = "python-socketio", extras = ["asyncio-client"], specifier = ">=5.14.0,<6.0.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=12.6.0" },
     { name = "tree-sitter", specifier = ">=0.21.3" },


### PR DESCRIPTION
This pull request makes minor dependency and packaging adjustments to the project. The most notable change is a slight update to the `pydantic` dependency version range, along with a formatting change in the `pyproject.toml` file for the source distribution configuration.

Dependency update:

* Updated the `pydantic` dependency lower bound from `2.12.2` to `2.11.9` in `pyproject.toml`, allowing for a broader range of compatible versions.

Packaging configuration:

* Reformatted the `include` list for the source distribution (`sdist`) in `pyproject.toml` to a single line without changing the included files.