### PR TITLE
Update permissions in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This pull request updates the permissions for the documentation deployment workflow in `.github/workflows/docs.yml`. The permissions have been adjusted to be more specific and secure.

Workflow permission updates:

* Changed the `contents` permission from `write` to `read` to limit access and improve security.
* Added `pages: write` permission to allow deployment to GitHub Pages.
* Added `id-token: write` permission, likely required for authentication with GitHub Pages or other OIDC integrations.