### PR TITLE
Update release workflow permissions and conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,22 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
-  id-token: write # Required for trusted publishing to PyPI/TestPyPI
+  contents: read
+  actions: read
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_repository.fork == false &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout target SHA
@@ -20,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Detect tag and pre-release
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.head_repository.fork == false &&
-      github.event.workflow_run.event == 'push' &&
-      startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases to improve security and ensure that releases are only triggered from appropriate sources. The most important changes are grouped below.

**Security and Permissions:**

* Reduced default workflow permissions from `contents: write` and `id-token: write` to `contents: read` and `actions: read`, limiting write access except where explicitly needed.
* Moved `contents: write` and `id-token: write` permissions into the `release` job, so these elevated permissions are only granted when the release job runs.

**Release Trigger Conditions:**

* Added stricter conditions to the `release` job to ensure it only runs when the workflow is triggered by a successful push event from the main repository (not forks), and when the branch name starts with `refs/tags/` (i.e., for tags only).

**Workflow Step Improvements:**

* Updated the `actions/checkout` step to set `persist-credentials: false`, further reducing the risk of credential leaks during the workflow.