### PR TITLE
Update permissions for security job in workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,15 +6,19 @@ on:
   schedule:
     - cron: '0 3 * * 1'
 
-permissions:
-  contents: read
-  security-events: write
-  id-token: write
-
 jobs:
   scorecard:
     name: OpenSSF Scorecard
     runs-on: ubuntu-latest
+    permissions:
+      # Required when publishing results (badge / API / code scanning)
+      security-events: write
+      id-token: write
+      # Recommended reads for private repos to avoid GraphQL/SAST gaps
+      contents: read
+      issues: read
+      pull-requests: read
+      checks: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
This pull request updates the permissions block in the `security.yml` GitHub Actions workflow to improve security and ensure proper access for the OpenSSF Scorecard job. The permissions are now scoped directly to the `scorecard` job and expanded to cover recommended read access for private repositories.

Security and workflow improvements:

* Moved the `permissions` block from the workflow level to the `scorecard` job level, ensuring permissions are only granted to the relevant job.
* Expanded permissions to include `issues: read`, `pull-requests: read`, and `checks: read` in addition to existing permissions, addressing gaps for private repositories and improving integration with GitHub features.