### PR TITLE
Remove customManagers from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,19 +5,6 @@
   "enabledManagers": [
     "pep621"
   ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["pyproject.toml"],
-      "matchStrings": [
-        "(?s).*"
-      ],
-      "datasourceTemplate": "pypi",
-      "depNameTemplate": "python-deps",
-      "versioningTemplate": "pep440",
-      "updateCommand": "uv lock"
-    }
-  ],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [


### PR DESCRIPTION
Removed custom managers configuration for regex matching.