### PR TITLE
fix(ci): dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
-
-      - name: Set up Python
-        run: uv python install 3.13
 
       - name: Install dependencies
         run: uv sync --locked --group dev --group test --group docs
@@ -85,13 +87,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
-
-      - name: Set up Python
-        run: uv python install 3.13
 
       - name: Install dependencies
         run: uv sync --locked --group dev --group test
@@ -117,13 +121,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+
       - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
-
-      - name: Set up Python ${{ matrix.python }}
-        run: uv python install ${{ matrix.python }}
 
       - name: Install dependencies
         run: uv sync --locked --group test
@@ -139,13 +145,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
-
-      - name: Set up Python
-        run: uv python install 3.13
 
       - name: Install dependencies
         run: uv sync --locked --group docs
@@ -170,13 +178,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
-
-      - name: Set up Python
-        run: uv python install 3.13
 
       - name: Install dependencies
         run: uv sync --locked --group dev

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -43,14 +43,6 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for CI to pass
-        uses: lewagon/wait-on-check-action@v1.5.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: "build"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-
       - name: Enable auto-merge (squash)
         uses: peter-evans/enable-pull-request-automerge@v3
         with:


### PR DESCRIPTION
Fixes Dependabot automation workflow failing on PRs because it waits for a non-existent check named 'build'.\n\nThis removes the wait step; auto-merge will still only complete once required checks pass.