### PR TITLE
Prepare 2026.4.1 release changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,5 +63,7 @@
   // ─────────────────────────────────────────────────────────────
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml"
-  }
+  },
+  "cursorpyright.analysis.autoImportCompletions": true,
+  "cursorpyright.analysis.typeCheckingMode": "basic"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.rst"
 authors = [{ name = "MarPi82", email = "marpi82.dev@google.com" }]
 maintainers = [{ name = "MarPi82", email = "marpi82.dev@google.com" }]
 license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.13.2,<4"
 keywords = [
   "home",
@@ -71,7 +72,6 @@ include = [
   "src/pybragerone",
   "README.rst",
   "docs/guides/getting_started.rst",
-  "LICENSE",
 ]
 
 [dependency-groups]

--- a/src/pybragerone/models/catalog.py
+++ b/src/pybragerone/models/catalog.py
@@ -710,9 +710,10 @@ class LiveAssetsCatalog:
             # Pattern examples:
             # "../config/router/deviceMenu/N/module.menu.ts":()=>d(()=>import("./module.menu-HASH.js"))
             # "../../config/router/deviceMenu/N/module.menu.ts":()=>d(()=>import('./module.menu-HASH.js'))
+            # "/src/config/router/deviceMenu/N/module.menu.ts":()=>_(()=>import("./module.menu-HASH.js"))
             device_menu_pattern = (
-                r"['\"](?:\.\./)+config/router/deviceMenu/(\d+)/module\.menu\.ts['\"]"
-                r"\s*:\s*\(\)\s*=>\s*d\s*\(\s*\(\)\s*=>\s*import\s*\(\s*"
+                r"['\"](?:(?:\.\./)+config/router|/src/config/router)/deviceMenu/(\d+)/module\.menu\.ts['\"]"
+                r"\s*:\s*\(\)\s*=>\s*[A-Za-z_$][\w$]*\s*\(\s*\(\)\s*=>\s*import\s*\(\s*"
                 r"['\"]\./(module\.menu-[A-Za-z0-9_-]+)\.js['\"]\s*\)"
             )
 

--- a/src/pybragerone/models/menu_manager.py
+++ b/src/pybragerone/models/menu_manager.py
@@ -67,7 +67,6 @@ class MenuProcessor:
             Processed MenuResult with clean Pydantic models
         """
         working_routes = self._deep_copy_routes(self.raw_menu.routes)
-
         # Step 1: Apply permission filtering if requested
         if filter_permissions is not None:
             working_routes = self._apply_permission_filter(working_routes, filter_permissions, include_invisible)
@@ -204,6 +203,20 @@ class MenuProcessor:
             children = node.get("children") or []
             node["children"] = [gate(child) for child in children if isinstance(child, dict)]
 
+            def has_any_parameters(container: dict[str, Any] | None) -> bool:
+                if not isinstance(container, dict):
+                    return False
+                for section in ("read", "write", "status", "special"):
+                    items = container.get(section)
+                    if isinstance(items, list) and len(items) > 0:
+                        return True
+                return False
+
+            # Keep route visible when it contains accessible params/children even if
+            # route-level permission is stricter than parameter-level permission.
+            if not visible and (node.get("children") or has_any_parameters(node.get("parameters"))):
+                visible = True
+
             node["_visible"] = visible
             return node
 
@@ -316,17 +329,19 @@ class MenuProcessor:
                 if m:
                     prefixes.add(m.group("prefix"))
 
-            # Check parameter permissions
-            params = meta.get("parameters", {})
-            for section in ("read", "write", "status", "special"):
-                items = params.get(section, [])
-                for item in items:
-                    if isinstance(item, dict):
-                        item_perm = item.get("permissionModule", "")
-                        if item_perm:
-                            m = prefix_re.match(str(item_perm))
-                            if m:
-                                prefixes.add(m.group("prefix"))
+            # Check parameter permissions from both meta.parameters and route.parameters.
+            for params in (meta.get("parameters", {}), route.get("parameters", {})):
+                if not isinstance(params, dict):
+                    continue
+                for section in ("read", "write", "status", "special"):
+                    items = params.get(section, [])
+                    for item in items:
+                        if isinstance(item, dict):
+                            item_perm = item.get("permissionModule", "")
+                            if item_perm:
+                                m = prefix_re.match(str(item_perm))
+                                if m:
+                                    prefixes.add(m.group("prefix"))
 
             # Scan children
             for child in route.get("children", []):

--- a/src/pybragerone/models/param_resolver.py
+++ b/src/pybragerone/models/param_resolver.py
@@ -593,21 +593,11 @@ class ParamResolver:
                 routes_meta.append((title, name, path, symbols, ancestors, route))
 
         if all_panels:
-            groups: dict[str, list[str]] = {}
-            taken: set[str] = set()
-            for _title, name, path, symbols, ancestors, route in routes_meta:
+            groups: dict[str, set[str]] = {}
+            for _title, _name, _path, symbols, ancestors, route in routes_meta:
                 panel_name = cls._panel_title_hierarchical(route=route, ancestors=ancestors, routes_i18n=routes_i18n)
-                if panel_name in taken:
-                    detail_parts = [part for part in (path, name) if part]
-                    if detail_parts:
-                        panel_name = f"{panel_name} [{' | '.join(detail_parts)}]"
-                idx = 2
-                while panel_name in taken:
-                    panel_name = f"{panel_name}#{idx}"
-                    idx += 1
-                taken.add(panel_name)
-                groups[panel_name] = sorted(symbols)
-            return groups
+                groups.setdefault(panel_name, set()).update(symbols)
+            return {panel: sorted(symbols) for panel, symbols in groups.items()}
 
         def pick_by_route(
             route_markers: list[str],

--- a/src/pybragerone/models/param_resolver.py
+++ b/src/pybragerone/models/param_resolver.py
@@ -609,35 +609,54 @@ class ParamResolver:
                 groups[panel_name] = sorted(symbols)
             return groups
 
-        def pick_by_route(route_markers: list[str], *, fallback_title_keywords: list[str]) -> set[str]:
+        def pick_by_route(
+            route_markers: list[str],
+            *,
+            fallback_title_keywords: list[str],
+            default_title: str,
+        ) -> tuple[str, set[str]]:
             markers = {cls._normalize_text(m) for m in route_markers if m}
             out: set[str] = set()
-            for _title, name, path, symbols, _ancestors, _route in routes_meta:
+            matched_title: str | None = None
+            for title, name, path, symbols, _ancestors, _route in routes_meta:
                 name_norm = cls._normalize_text(name)
                 path_norm = cls._normalize_text(path)
                 if any(marker and marker in (name_norm, path_norm) for marker in markers):
+                    if matched_title is None:
+                        matched_title = title
                     out |= symbols
 
             if out:
-                return out
+                return (matched_title or default_title), out
 
             want = [cls._normalize_text(k) for k in fallback_title_keywords]
             for title, _name, _path, symbols, _ancestors, _route in routes_meta:
                 t = cls._normalize_text(title)
                 if any(w and w in t for w in want):
+                    if matched_title is None:
+                        matched_title = title
                     out |= symbols
-            return out
+            return (matched_title or default_title), out
 
-        boiler = pick_by_route(["modules.menu.boiler", "boiler"], fallback_title_keywords=["boiler"])
-        dhw = pick_by_route(["modules.menu.dhw", "dhw"], fallback_title_keywords=["dhw"])
-        valve = pick_by_route(
+        boiler_title, boiler = pick_by_route(
+            ["modules.menu.boiler", "boiler"],
+            fallback_title_keywords=["boiler"],
+            default_title="Boiler",
+        )
+        dhw_title, dhw = pick_by_route(
+            ["modules.menu.dhw", "dhw"],
+            fallback_title_keywords=["dhw"],
+            default_title="DHW",
+        )
+        valve_title, valve = pick_by_route(
             ["modules.menu.valve1", "valve/1", "valve1"],
             fallback_title_keywords=["valve_1", "valve1"],
+            default_title="Valve 1",
         )
         return {
-            "Boiler": sorted(boiler),
-            "DHW": sorted(dhw),
-            "Valve 1": sorted(valve),
+            boiler_title: sorted(boiler),
+            dhw_title: sorted(dhw),
+            valve_title: sorted(valve),
         }
 
     @classmethod

--- a/tests/test_menu_manager.py
+++ b/tests/test_menu_manager.py
@@ -114,6 +114,36 @@ def test_hidden_children_removed_without_permission(nested_manager: tuple[MenuMa
     assert menu.routes[0].children == []
 
 
+def test_route_kept_when_parameter_permission_allows_access() -> None:
+    """Keep route visible when parameter-level permission grants access."""
+    manager = MenuManager()
+    device_menu = 2
+    manager.store_raw_menu(
+        device_menu=device_menu,
+        routes=[
+            {
+                "path": "/internet",
+                "name": "internet",
+                "meta": {"permissionModule": "DISPLAY_MENU_ADMIN", "displayName": "Internet"},
+                "parameters": {
+                    "write": [
+                        {
+                            "permissionModule": "DISPLAY_PARAMETER_LEVEL_1",
+                            "parameter": 'e(E.WRITE,"COMMAND_MODULE_RESTART")',
+                        }
+                    ]
+                },
+                "children": [],
+            }
+        ],
+    )
+
+    menu = manager.get_menu(device_menu, permissions={"DISPLAY_PARAMETER_LEVEL_1"})
+    assert len(menu.routes) == 1
+    assert menu.routes[0].name == "internet"
+    assert menu.routes[0].parameters.write[0].token == "COMMAND_MODULE_RESTART"
+
+
 def test_debug_mode_keeps_hidden_children(nested_manager: tuple[MenuManager, int]) -> None:
     """Debug mode should keep children even when inaccessible."""
     manager, device_menu = nested_manager
@@ -278,3 +308,19 @@ def test_device_menu_mapping_parsed_from_router_paths() -> None:
 
     assert idx.menu_map[0] == "module.menu-B60xPU0K"
     assert idx.menu_map[1] == "module.menu-lSoMfgab"
+
+
+def test_device_menu_mapping_parsed_from_src_router_paths() -> None:
+    """Parse deviceMenu mapping from /src router paths with arbitrary helper name."""
+    mock_api = AsyncMock()
+    catalog = LiveAssetsCatalog(mock_api)
+
+    index_code = b"""
+    {"/src/config/router/deviceMenu/0/module.menu.ts":()=>_(()=>import("./module.menu-DmY2Kb59.js"),__vite__mapDeps([0]))
+    ,"/src/config/router/deviceMenu/1/module.menu.ts":()=>_(()=>import("./module.menu-DCbbkfeq.js"),__vite__mapDeps([1]))}
+    """
+
+    idx = catalog._build_asset_index_from_index_js("https://one.brager.pl/assets/index-main.js", index_code)
+
+    assert idx.menu_map[0] == "module.menu-DmY2Kb59"
+    assert idx.menu_map[1] == "module.menu-DCbbkfeq"

--- a/tests/test_param_resolver_panels.py
+++ b/tests/test_param_resolver_panels.py
@@ -129,6 +129,37 @@ def test_build_panel_groups_from_menu_all_panels_uses_routes_i18n_titles() -> No
     assert groups["Użytkownik"] == ["PARAM_66"]
 
 
+def test_build_panel_groups_from_menu_all_panels_merges_duplicate_panel_titles() -> None:
+    """Merge symbols when multiple routes resolve to the same panel title."""
+    menu = MenuResult.model_validate(
+        {
+            "routes": [
+                {
+                    "path": "dhw",
+                    "name": "modules.menu.dhw",
+                    "meta": {
+                        "displayName": "CWU",
+                        "parameters": {"read": [{"parameter": "E(A.READ,'PARAM_P4_2')"}]},
+                    },
+                },
+                {
+                    "path": "boiler/dhw",
+                    "name": "modules.menu.boilerDHW",
+                    "meta": {
+                        "displayName": "CWU",
+                        "parameters": {"write": [{"parameter": "E(A.WRITE,'PARAM_51')"}]},
+                    },
+                },
+            ]
+        }
+    )
+
+    groups = ParamResolver.build_panel_groups_from_menu(menu, all_panels=True)
+
+    assert "CWU" in groups
+    assert groups["CWU"] == ["PARAM_51", "PARAM_P4_2"]
+
+
 def test_build_panel_groups_from_menu_all_panels_uses_parent_child_titles_for_duplicates() -> None:
     """Disambiguate duplicate child route titles via parent/child panel titles."""
     menu = MenuResult.model_validate(


### PR DESCRIPTION
## Summary
- carry over panel/menu fixes from the update branch into a merge-ready PR
- include PEP 639 `pyproject.toml` license metadata update
- include VSCode Cursor Pyright defaults used for local development consistency

## Test plan
- [x] Existing tests previously executed for panel/menu changes
- [ ] Run full test suite before tagging release
- [ ] After merge, create tag `2026.4.1` and verify GitHub release workflow publishes to PyPI

Made with [Cursor](https://cursor.com)