### PR TITLE
Fix null module interfaces and README PyPI badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,12 +5,12 @@ pybragerone
    :target: https://github.com/marpi82/py-bragerone/tags
    :alt: Latest Tag
 
-.. image:: https://img.shields.io/pypi/v/pybragerone?color=blue
-   :target: https://pypi.org/project/pybragerone/
+.. image:: https://img.shields.io/pypi/v/py-bragerone?color=blue
+   :target: https://pypi.org/project/py-bragerone/
    :alt: PyPI Version
 
-.. image:: https://img.shields.io/pypi/pyversions/pybragerone
-   :target: https://pypi.org/project/pybragerone/
+.. image:: https://img.shields.io/pypi/pyversions/py-bragerone
+   :target: https://pypi.org/project/py-bragerone/
    :alt: Python Versions
 
 .. image:: https://img.shields.io/github/license/marpi82/py-bragerone?color=green

--- a/src/pybragerone/models/api/modules.py
+++ b/src/pybragerone/models/api/modules.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class ModuleGateway(BaseModel):
@@ -14,6 +14,13 @@ class ModuleGateway(BaseModel):
     address: str
     interface: str
     version: str
+
+    @field_validator("interface", mode="before")
+    @classmethod
+    def _coerce_optional_interface(cls, value: Any) -> Any:
+        if value is None:
+            return ""
+        return value
 
 
 class ModuleParameterSchema(BaseModel):
@@ -47,6 +54,13 @@ class Module(BaseModel):
     moduleTitle: str
     isAcceptedAt: datetime
     isConnectedAt: datetime
+
+    @field_validator("moduleInterface", mode="before")
+    @classmethod
+    def _coerce_optional_module_interface(cls, value: Any) -> Any:
+        if value is None:
+            return ""
+        return value
 
 
 class ModuleCard(BaseModel):

--- a/tests/test_module_model_tolerates_null_interface.py
+++ b/tests/test_module_model_tolerates_null_interface.py
@@ -1,0 +1,40 @@
+"""Regression test for null module interface fields."""
+
+from __future__ import annotations
+
+from pybragerone.models.api.modules import Module
+
+
+def test_module_model_tolerates_null_interfaces() -> None:
+    """Module model accepts null interfaces from API payloads."""
+    payload = {
+        "devid": "FTTCTBSLCE",
+        "name": "Module name",
+        "gateway": {
+            "address": "gateway-addr",
+            "interface": None,
+            "version": "1.0",
+        },
+        "deviceMenu": 0,
+        "deviceLanguageVariant": 0,
+        "devices": [],
+        "services": [],
+        "permissions": [],
+        "acceptedAt": 0,
+        "connectedAt": 0,
+        "moduleAlarms": 0,
+        "parameterSchemas": [],
+        "id": 1,
+        "moduleAddress": "module-addr",
+        "moduleInterface": None,
+        "moduleVersion": "2.08",
+        "moduleServices": [],
+        "moduleTitle": "HT DasPell GL 37kW",
+        "isAcceptedAt": "2026-04-06T00:00:00Z",
+        "isConnectedAt": "2026-04-06T00:00:00Z",
+    }
+
+    module = Module.model_validate(payload)
+
+    assert module.gateway.interface == ""
+    assert module.moduleInterface == ""


### PR DESCRIPTION
## Summary
- make module models tolerant of API payloads where `gateway.interface` and `moduleInterface` are `null`
- add regression test for null-interface payload validation
- fix README PyPI badge package name from `pybragerone` to `py-bragerone`

## Test plan
- [x] `uv run ruff check src/pybragerone/models/api/modules.py tests/test_module_model_tolerates_null_interface.py`
- [x] `uv run pytest -q tests/test_module_model_tolerates_null_interface.py`

Made with [Cursor](https://cursor.com)