### PR TITLE
Add websocket self-healing reconnect supervisor

### DIFF
--- a/src/pybragerone/api/ws.py
+++ b/src/pybragerone/api/ws.py
@@ -333,8 +333,7 @@ class RealtimeManager:
         self._supervisor_task = None
         if task is not None and not task.done():
             task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
+            await asyncio.gather(task, return_exceptions=True)
         if self._sio.connected:
             await self._sio.disconnect()
 

--- a/src/pybragerone/api/ws.py
+++ b/src/pybragerone/api/ws.py
@@ -253,17 +253,29 @@ class RealtimeManager:
 
     async def connect(self) -> None:
         """Open a Socket.IO connection with appropriate headers and wait for join."""
-        self._start_supervisor()
         await self._ensure_connected(initial=True)
         # Short grace period to ensure the namespace is fully established
         await self._connected.wait()
         await asyncio.sleep(0.1)
+        self._start_supervisor()
 
     def _start_supervisor(self) -> None:
-        if self._supervisor_running and self._supervisor_task is not None and not self._supervisor_task.done():
+        if self._supervisor_task is not None and not self._supervisor_task.done():
             return
         self._supervisor_running = True
-        spawn(self._connection_supervisor(), "ws_connection_supervisor", log)
+        task = asyncio.create_task(
+            self._connection_supervisor(),
+            name="ws_connection_supervisor",
+        )
+        self._supervisor_task = task
+
+        def _supervisor_done(done_task: asyncio.Task[None]) -> None:
+            with suppress(asyncio.CancelledError):
+                done_task.result()
+            if self._supervisor_task is done_task:
+                self._supervisor_task = None
+
+        task.add_done_callback(_supervisor_done)
 
     async def _ensure_connected(self, *, initial: bool) -> None:
         if self._sio.connected and self._connected.is_set():
@@ -293,7 +305,6 @@ class RealtimeManager:
                 log.warning("WS supervisor reconnect failed", exc_info=True)
 
     async def _connection_supervisor(self) -> None:
-        self._supervisor_task = asyncio.current_task()
         try:
             while self._supervisor_running:
                 await asyncio.sleep(self._supervisor_interval_s)
@@ -303,8 +314,6 @@ class RealtimeManager:
                 await self._ensure_connected(initial=False)
         except asyncio.CancelledError:
             raise
-        finally:
-            self._supervisor_task = None
 
     def sid(self) -> str | None:
         """Return the namespace SID (``/ws``), if available."""
@@ -320,10 +329,12 @@ class RealtimeManager:
     async def disconnect(self) -> None:
         """Close the Socket.IO connection if open."""
         self._supervisor_running = False
-        if self._supervisor_task is not None:
-            self._supervisor_task.cancel()
+        task = self._supervisor_task
+        self._supervisor_task = None
+        if task is not None and not task.done():
+            task.cancel()
             with suppress(asyncio.CancelledError):
-                await self._supervisor_task
+                await task
         if self._sio.connected:
             await self._sio.disconnect()
 

--- a/src/pybragerone/api/ws.py
+++ b/src/pybragerone/api/ws.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from typing import (
     Any,
     Protocol,
@@ -98,6 +99,10 @@ class RealtimeManager:
         self._on_event: EventDispatcher | None = None
         self._modules: list[str] = []
         self._group_id: int | None = None
+        self._connect_lock = asyncio.Lock()
+        self._supervisor_task: asyncio.Task[None] | None = None
+        self._supervisor_running = False
+        self._supervisor_interval_s = 15.0
 
         # Configure AsyncClient with reconnection enabled.
         self._sio: socketio.AsyncClient = socketio.AsyncClient(
@@ -183,6 +188,7 @@ class RealtimeManager:
 
     async def _on_connect_error(self, data: Any | None = None) -> None:
         log.warning("WS connect_error: %s", data)
+        self._connected.clear()
 
     async def _on_reconnect(self) -> None:
         log.info("WS reconnect OK")
@@ -247,23 +253,58 @@ class RealtimeManager:
 
     async def connect(self) -> None:
         """Open a Socket.IO connection with appropriate headers and wait for join."""
-        headers = {
-            "Authorization": f"Bearer {self._token}",
-            "Origin": self._origin,
-            "Referer": self._referer,
-            "Accept-Language": "pl-PL,pl;q=0.9",
-            "x-appversion": "1.1.78",
-        }
-        await self._sio.connect(
-            self._io_base,
-            headers=headers,
-            transports=["pooling", "websocket"],
-            socketio_path=self._socket_path,
-            namespaces=[self._namespace],
-        )
+        self._start_supervisor()
+        await self._ensure_connected(initial=True)
         # Short grace period to ensure the namespace is fully established
         await self._connected.wait()
         await asyncio.sleep(0.1)
+
+    def _start_supervisor(self) -> None:
+        if self._supervisor_running and self._supervisor_task is not None and not self._supervisor_task.done():
+            return
+        self._supervisor_running = True
+        spawn(self._connection_supervisor(), "ws_connection_supervisor", log)
+
+    async def _ensure_connected(self, *, initial: bool) -> None:
+        if self._sio.connected and self._connected.is_set():
+            return
+        async with self._connect_lock:
+            if self._sio.connected and self._connected.is_set():
+                return
+            headers = {
+                "Authorization": f"Bearer {self._token}",
+                "Origin": self._origin,
+                "Referer": self._referer,
+                "Accept-Language": "pl-PL,pl;q=0.9",
+                "x-appversion": "1.1.78",
+            }
+            try:
+                await self._sio.connect(
+                    self._io_base,
+                    headers=headers,
+                    transports=["pooling", "websocket"],
+                    socketio_path=self._socket_path,
+                    namespaces=[self._namespace],
+                )
+            except Exception:
+                self._connected.clear()
+                if initial:
+                    raise
+                log.warning("WS supervisor reconnect failed", exc_info=True)
+
+    async def _connection_supervisor(self) -> None:
+        self._supervisor_task = asyncio.current_task()
+        try:
+            while self._supervisor_running:
+                await asyncio.sleep(self._supervisor_interval_s)
+                if self._sio.connected and self._connected.is_set():
+                    continue
+                log.warning("WS disconnected state detected; forcing reconnect")
+                await self._ensure_connected(initial=False)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            self._supervisor_task = None
 
     def sid(self) -> str | None:
         """Return the namespace SID (``/ws``), if available."""
@@ -278,6 +319,11 @@ class RealtimeManager:
 
     async def disconnect(self) -> None:
         """Close the Socket.IO connection if open."""
+        self._supervisor_running = False
+        if self._supervisor_task is not None:
+            self._supervisor_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._supervisor_task
         if self._sio.connected:
             await self._sio.disconnect()
 

--- a/tests/test_ws_self_heal.py
+++ b/tests/test_ws_self_heal.py
@@ -20,6 +20,7 @@ class FakeAsyncClient:
         self.sid: str | None = "ENG-SID"
         self._handlers: dict[tuple[str, str], Any] = {}
         self.connect_calls = 0
+        self.reconnect_event = asyncio.Event()
 
     def on(self, event: str, handler: Any, namespace: str) -> None:
         """Register an event handler under namespace/event key."""
@@ -28,6 +29,8 @@ class FakeAsyncClient:
     async def connect(self, *args: Any, **kwargs: Any) -> None:
         """Simulate a successful socket connect and emit connect callback."""
         self.connect_calls += 1
+        if self.connect_calls > 1:
+            self.reconnect_event.set()
         self.connected = True
         namespace = kwargs.get("namespaces", ["/ws"])[0]
         self.namespaces = [namespace]
@@ -63,7 +66,7 @@ async def test_realtime_manager_forces_reconnect_when_disconnected(monkeypatch: 
     fake.connected = False
     await manager._on_disconnect()
 
-    await asyncio.sleep(0.05)
+    await asyncio.wait_for(fake.reconnect_event.wait(), timeout=1.0)
     assert fake.connect_calls >= 2
 
     await manager.disconnect()

--- a/tests/test_ws_self_heal.py
+++ b/tests/test_ws_self_heal.py
@@ -1,0 +1,69 @@
+"""Tests for websocket self-healing behavior in RealtimeManager."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from pybragerone.api.ws import RealtimeManager
+
+
+class FakeAsyncClient:
+    """Minimal AsyncClient stub used by RealtimeManager tests."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize fake socket state and event handlers."""
+        self.connected = False
+        self.namespaces: list[str] = []
+        self.sid: str | None = "ENG-SID"
+        self._handlers: dict[tuple[str, str], Any] = {}
+        self.connect_calls = 0
+
+    def on(self, event: str, handler: Any, namespace: str) -> None:
+        """Register an event handler under namespace/event key."""
+        self._handlers[(namespace, event)] = handler
+
+    async def connect(self, *args: Any, **kwargs: Any) -> None:
+        """Simulate a successful socket connect and emit connect callback."""
+        self.connect_calls += 1
+        self.connected = True
+        namespace = kwargs.get("namespaces", ["/ws"])[0]
+        self.namespaces = [namespace]
+        handler = self._handlers.get((namespace, "connect"))
+        if handler is not None:
+            await handler()
+
+    async def disconnect(self) -> None:
+        """Simulate socket disconnect."""
+        self.connected = False
+
+    async def emit(self, *args: Any, **kwargs: Any) -> None:
+        """Accept emits without side effects for this test."""
+        return None
+
+    def get_sid(self, namespace: str) -> str:
+        """Return deterministic namespace SID."""
+        return f"NS-{namespace}"
+
+
+@pytest.mark.asyncio
+async def test_realtime_manager_forces_reconnect_when_disconnected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Supervisor should reconnect if client remains disconnected."""
+    fake = FakeAsyncClient()
+    monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
+
+    manager = RealtimeManager(token="tkn")
+    manager._supervisor_interval_s = 0.01
+
+    await manager.connect()
+    assert fake.connect_calls == 1
+
+    fake.connected = False
+    await manager._on_disconnect()
+
+    await asyncio.sleep(0.05)
+    assert fake.connect_calls >= 2
+
+    await manager.disconnect()


### PR DESCRIPTION
## Summary
- add a lightweight websocket supervisor in `RealtimeManager` that detects disconnected/stalled states and forces reconnect attempts
- clear connected state on `connect_error` so the gateway can reliably detect broken sessions
- add regression coverage to verify automatic reconnect is attempted after disconnect

## Test plan
- [x] `uv run ruff check src tests`
- [x] `uv run pytest -q tests/test_ws_self_heal.py tests/test_gateway_prime_reconnect.py`
- [x] pre-commit hooks pass during commit (ruff, mypy, bandit, semgrep)


Made with [Cursor](https://cursor.com)