### PR TITLE
Pin setup-script downloads with SHA256 verification

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 echo "🚀 Setting up py-bragerone devcontainer..."
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# shellcheck source=../scripts/lib/install_uv.sh
-source "${ROOT_DIR}/scripts/lib/install_uv.sh"
+# shellcheck source=../scripts/install_uv.sh
+source "${ROOT_DIR}/scripts/install_uv.sh"
 
 # Install system dependencies (with sudo if running as non-root)
 echo "📦 Installing system dependencies..."

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 
 echo "🚀 Setting up py-bragerone devcontainer..."
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../scripts/lib/install_uv.sh
+source "${ROOT_DIR}/scripts/lib/install_uv.sh"
+
 # Install system dependencies (with sudo if running as non-root)
 echo "📦 Installing system dependencies..."
 if [ "$EUID" -ne 0 ]; then
@@ -11,21 +15,21 @@ if [ "$EUID" -ne 0 ]; then
     sudo apt-get install -y --no-install-recommends \
         build-essential \
         curl \
-        git \
-        ca-certificates
+        ca-certificates \
+        git
 else
     apt-get update
     apt-get install -y --no-install-recommends \
         build-essential \
         curl \
-        git \
-        ca-certificates
+        ca-certificates \
+        git
 fi
 
-# Install uv for current user
-echo "📦 Installing uv..."
-curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
+# Install uv from a version+SHA256-pinned GitHub release (no curl|sh).
+echo "📦 Installing uv (hash-pinned ${UV_VERSION})..."
+install_uv_pinned "${HOME}/.local/bin"
+export PATH="${HOME}/.local/bin:${PATH}"
 
 # Fix permissions for mounted volumes (they may be owned by root)
 echo "🔧 Fixing volume permissions..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YYYY.M.PATCH`
 - Harden GitHub Actions workflows (pin actions by SHA, least-privilege permissions).
 - Trigger releases from tag pushes instead of `workflow_run` checkout.
 - Add Hypothesis property-based tests and an Atheris fuzz harness for parsers.
+- Install `uv` in setup scripts from a version- and SHA256-pinned GitHub release
+  (no `curl | sh` / unpinned `pip install`); verify the GitHub CLI apt keyring digest.
 
 ### Changed
 

--- a/scripts/install_uv.sh
+++ b/scripts/install_uv.sh
@@ -1,0 +1,76 @@
+# shellcheck shell=bash
+# Shared helper: install a hash-pinned uv release binary from GitHub.
+#
+# Bump procedure:
+#   1. Pick a tag from https://github.com/astral-sh/uv/releases
+#   2. Download sha256.sum from that release
+#   3. Update UV_VERSION and the hashes below for linux gnu x86_64 / aarch64
+#
+# Usage (from a repo checkout):
+#   # shellcheck source=scripts/install_uv.sh
+#   source "${ROOT_DIR}/scripts/install_uv.sh"
+#   install_uv_pinned
+
+UV_VERSION="${UV_VERSION:-0.12.3}"
+
+# Official release digests for UV_VERSION (from release asset sha256.sum).
+UV_SHA256_LINUX_X86_64_GNU="600cf9a742aca00d292673b16b5acffaa7b8c269a364ad0c2e79498dcb1fe101"
+UV_SHA256_LINUX_AARCH64_GNU="bb66cb52e7b1823aed1183630d8d8e5c958840d584a4c55ec10a4cfc168dcca2"
+
+install_uv_pinned() {
+  local dest_dir="${1:-${HOME}/.local/bin}"
+  local arch tarball expected tmpdir archive
+
+  if command -v uv >/dev/null 2>&1; then
+    echo "  uv already installed ($(uv --version | head -n1)); skipping pinned download"
+    return 0
+  fi
+
+  arch="$(uname -m)"
+  case "${arch}" in
+    x86_64 | amd64)
+      tarball="uv-x86_64-unknown-linux-gnu.tar.gz"
+      expected="${UV_SHA256_LINUX_X86_64_GNU}"
+      ;;
+    aarch64 | arm64)
+      tarball="uv-aarch64-unknown-linux-gnu.tar.gz"
+      expected="${UV_SHA256_LINUX_AARCH64_GNU}"
+      ;;
+    *)
+      echo "Unsupported architecture for pinned uv install: ${arch}" >&2
+      echo "Install uv manually from https://github.com/astral-sh/uv/releases/tag/${UV_VERSION}" >&2
+      return 1
+      ;;
+  esac
+
+  tmpdir="$(mktemp -d)"
+  archive="${tmpdir}/${tarball}"
+  echo "  Downloading uv ${UV_VERSION} (${tarball})..."
+  if ! curl -fsSL \
+    "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${tarball}" \
+    -o "${archive}"; then
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  echo "  Verifying SHA256..."
+  if ! echo "${expected}  ${archive}" | sha256sum -c -; then
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  mkdir -p "${dest_dir}"
+  tar -xzf "${archive}" -C "${tmpdir}"
+  install -m 0755 "${tmpdir}/uv" "${dest_dir}/uv"
+  if [[ -f "${tmpdir}/uvx" ]]; then
+    install -m 0755 "${tmpdir}/uvx" "${dest_dir}/uvx"
+  fi
+  rm -rf "${tmpdir}"
+
+  export PATH="${dest_dir}:${PATH}"
+  command -v uv >/dev/null 2>&1 || {
+    echo "uv binary installed to ${dest_dir} but not found on PATH" >&2
+    return 1
+  }
+  echo "  ✅ uv $(uv --version | head -n1) installed to ${dest_dir} (SHA256 verified)"
+}

--- a/scripts/setup_host_env.sh
+++ b/scripts/setup_host_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Setup script for py-bragerone development environment on host
-# This script prepares system deps, installs uv via pipx, and syncs the project env
+# Prepares system deps, installs hash-pinned uv, and syncs the project env.
 set -euo pipefail
 
 echo "🚀 Setting up py-bragerone development environment..."
@@ -12,11 +12,20 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/install_uv.sh
+source "${ROOT_DIR}/scripts/lib/install_uv.sh"
+
+# Pinned digest of https://cli.github.com/packages/githubcli-archive-keyring.gpg
+# Bump when GitHub rotates the apt keyring.
+GH_CLI_KEYRING_SHA256="6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b"
+
 # ---------------------------------------------------------------------------
 # 1. Ensure we're on Debian/Ubuntu (script uses apt)
 # ---------------------------------------------------------------------------
 if ! command -v apt >/dev/null 2>&1; then
     echo "⚠️  This script targets Debian/Ubuntu systems. Adjust package commands for your distro."
+    exit 1
 fi
 
 # ---------------------------------------------------------------------------
@@ -26,49 +35,34 @@ echo -e "${BLUE}📦 Installing system dependencies...${NC}"
 if ! command -v python3 >/dev/null 2>&1 || ! python3 -m pip --version >/dev/null 2>&1; then
     echo "  Installing python3-pip, python3-venv, python3-dev, build-essential..."
     sudo apt update
-    sudo apt install -y python3-pip python3-venv python3-dev build-essential
+    sudo apt install -y python3-pip python3-venv python3-dev build-essential curl ca-certificates
 else
     echo "  ✅ Python 3 tooling already installed"
+    sudo apt install -y curl ca-certificates >/dev/null
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Install pipx for isolated CLI tools
-# ---------------------------------------------------------------------------
-echo -e "${BLUE}📦 Ensuring pipx is available...${NC}"
-if ! command -v pipx >/dev/null 2>&1; then
-    if command -v apt >/dev/null 2>&1; then
-        sudo apt install -y pipx
-    else
-        python3 -m pip install --user pipx
-        python3 -m pipx ensurepath
-    fi
-    echo "  ✅ pipx installed"
-else
-    echo "  ✅ pipx already present"
-fi
-
-# ---------------------------------------------------------------------------
-# 3a. Install GitHub CLI (gh)
+# 3. Install GitHub CLI (gh) with a hash-verified apt keyring
 # ---------------------------------------------------------------------------
 echo -e "${BLUE}📦 Installing GitHub CLI (gh)...${NC}"
 if ! command -v gh >/dev/null 2>&1; then
-    if command -v apt >/dev/null 2>&1; then
-        echo "  Installing gh via official repository..."
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        sudo apt update
-        sudo apt install -y gh
-        echo "  ✅ GitHub CLI installed"
-    else
-        echo "  ⚠️  Cannot install gh automatically on this system. Please install manually."
-    fi
+    echo "  Installing gh via official repository (keyring SHA256-verified)..."
+    tmp_keyring="$(mktemp)"
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o "${tmp_keyring}"
+    echo "${GH_CLI_KEYRING_SHA256}  ${tmp_keyring}" | sha256sum -c -
+    sudo install -m 0644 "${tmp_keyring}" /usr/share/keyrings/githubcli-archive-keyring.gpg
+    rm -f "${tmp_keyring}"
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+    sudo apt update
+    sudo apt install -y gh
+    echo "  ✅ GitHub CLI installed"
 else
     echo "  ✅ GitHub CLI already installed ($(gh --version | head -n1))"
 fi
 
 # ---------------------------------------------------------------------------
-# 4. Add ~/.local/bin to PATH (pipx install location)
+# 4. Add ~/.local/bin to PATH
 # ---------------------------------------------------------------------------
 echo -e "${BLUE}🔧 Configuring PATH...${NC}"
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
@@ -81,18 +75,14 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Install uv (dependency manager) via pipx
+# 5. Install uv from a version+SHA256-pinned GitHub release (no pipx / curl|sh)
 # ---------------------------------------------------------------------------
-echo -e "${BLUE}📦 Installing uv...${NC}"
-if ! command -v uv >/dev/null 2>&1; then
-    pipx install uv
-    echo "  ✅ uv installed"
-else
-    echo "  ✅ uv already installed ($(uv --version | head -n1))"
-fi
+echo -e "${BLUE}📦 Installing uv (hash-pinned ${UV_VERSION})...${NC}"
+install_uv_pinned "${HOME}/.local/bin"
+export PATH="${HOME}/.local/bin:${PATH}"
 
 # ---------------------------------------------------------------------------
-# 7. Recommend helpful environment defaults
+# 6. Recommend helpful environment defaults
 # ---------------------------------------------------------------------------
 echo -e "${BLUE}ℹ️  Setting recommended environment defaults...${NC}"
 if ! grep -q "UV_PROJECT_ENVIRONMENT" "$HOME/.bashrc" 2>/dev/null; then
@@ -114,21 +104,22 @@ export UV_LINK_MODE="copy"
 export RUFF_NUM_THREADS="1"
 
 # ---------------------------------------------------------------------------
-# 8. Sync project dependencies with uv
+# 7. Sync project dependencies with uv
 # ---------------------------------------------------------------------------
 echo -e "${BLUE}📦 Syncing project dependencies (uv sync)...${NC}"
+cd "${ROOT_DIR}"
 uv sync --locked --group dev --group test --group docs
 echo "  ✅ Dependencies installed into .venv/"
 
 # ---------------------------------------------------------------------------
-# 9. Install pre-commit hooks inside the project environment
+# 8. Install pre-commit hooks inside the project environment
 # ---------------------------------------------------------------------------
 echo -e "${BLUE}🪝 Installing pre-commit hooks...${NC}"
 uv run --group dev pre-commit install
 echo "  ✅ pre-commit hooks installed"
 
 # ---------------------------------------------------------------------------
-# 10. Verify setup
+# 9. Verify setup
 # ---------------------------------------------------------------------------
 echo ""
 echo -e "${GREEN}✅ Setup complete!${NC}"

--- a/scripts/setup_host_env.sh
+++ b/scripts/setup_host_env.sh
@@ -13,8 +13,8 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# shellcheck source=lib/install_uv.sh
-source "${ROOT_DIR}/scripts/lib/install_uv.sh"
+# shellcheck source=install_uv.sh
+source "${ROOT_DIR}/scripts/install_uv.sh"
 
 # Pinned digest of https://cli.github.com/packages/githubcli-archive-keyring.gpg
 # Bump when GitHub rotates the apt keyring.


### PR DESCRIPTION
## Summary
- Add `scripts/lib/install_uv.sh` for version- and SHA256-pinned `uv` installs from GitHub Releases (x86_64/aarch64 linux gnu).
- Update `.devcontainer/setup.sh` and `scripts/setup_host_env.sh` to use it (no `curl | sh`, no unpinned `pip install`).
- Verify the GitHub CLI apt keyring digest before installing `gh`.

## Test plan
- [x] `bash -n` on updated scripts
- [x] Smoke: download uv 0.12.3 tarball and `sha256sum -c` against embedded digest
- [ ] CI green
- [ ] Re-run Security Checks; Scorecard `#91` / `#92` should clear