### PR TITLE
Release 2026.8.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "dependabot"
@@ -13,6 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: "direct"
     ignore:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   "timezone": "Europe/Warsaw",
   "dependencyDashboard": true,
   "prConcurrentLimit": 4,
+  "minimumReleaseAge": "7 days",
   "enabledManagers": [
     "pep621"
   ],
@@ -24,7 +25,8 @@
         "project.dependencies"
       ],
       "groupName": "python runtime deps",
-      "groupSlug": "python-runtime-deps"
+      "groupSlug": "python-runtime-deps",
+      "minimumReleaseAge": "7 days"
     },
     {
       "matchManagers": [
@@ -36,7 +38,8 @@
         "build-system.requires"
       ],
       "groupName": "python dev/test/docs deps",
-      "groupSlug": "python-dev-deps"
+      "groupSlug": "python-dev-deps",
+      "minimumReleaseAge": "7 days"
     },
     {
       "matchManagers": [
@@ -46,7 +49,8 @@
         "minor",
         "patch"
       ],
-      "automerge": true
+      "automerge": true,
+      "minimumReleaseAge": "7 days"
     }
   ],
   "labels": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YYYY.M.PATCH`
 
 ## [Unreleased]
 
+## [2026.8.1] - 2026-08-08
+
 ### Security
 
 - Harden GitHub Actions workflows (pin actions by SHA, least-privilege permissions).
@@ -14,10 +16,13 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YYYY.M.PATCH`
 - Add Hypothesis property-based tests and an Atheris fuzz harness for parsers.
 - Install `uv` in setup scripts from a version- and SHA256-pinned GitHub release
   (no `curl | sh` / unpinned `pip install`); verify the GitHub CLI apt keyring digest.
+- Add OpenSSF Best Practices badge and supporting project docs (`CHANGELOG`,
+  `CONTRIBUTING`, `CODE_OF_CONDUCT`, `CODEOWNERS`).
 
 ### Changed
 
 - Normalize `asyncio` imports in the gateway module for CodeQL maintainability.
+- Tighten supported Python range to `>=3.13.2,<3.15`.
 
 ## [2026.4.5] - 2026-04-14
 


### PR DESCRIPTION
## Summary
- Prepare `CHANGELOG.md` for CalVer tag `2026.8.1`.
- Add Dependabot `cooldown` and Renovate `minimumReleaseAge` (Semgrep p/ci).

## Test plan
- [ ] Merge to main
- [ ] Tag `2026.8.1` and confirm Release workflow publishes PyPI + GitHub Release