### PR TITLE
Add Copilot code review customization

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -39,11 +39,11 @@ uv run --group dev poe fix
 uv run --group dev poe typecheck
 
 # Full validation (quality + security + tests)
-uv run --group dev poe validate
+uv run --group dev --group test poe validate
 
 # Build documentation
-uv run --group docs poe docs-build
-uv run --group docs poe docs-serve
+uv run --group dev --group docs poe docs-build
+uv run --group dev --group docs poe docs-serve
 
 # Run pre-commit hooks manually
 uv run --group dev pre-commit run --all-files

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -198,12 +198,14 @@ All code must pass `mypy --strict`. Use explicit types, no `Any` without justifi
 - Never block event loop; use `asyncio.to_thread()` for sync operations
 - EventBus subscribers: always wrap in try/except to prevent task death
 
-Example from `gateway.py`:
+Pattern from `gateway.py`:
 ```python
-async def _ws_dispatch(self, event_name: str, payload: Any) -> None:
-    # Never let exceptions kill the dispatcher
-    with contextlib.suppress(Exception):
-        await self._process_event(event_name, payload)
+try:
+    res = cb(*args, **kwargs)
+    if asyncio.iscoroutine(res):
+        await res
+except Exception:
+    LOG.exception("Callback error")  # never let a callback kill the dispatcher
 ```
 
 ### 4. Error Handling
@@ -281,7 +283,7 @@ These files should be kept in sync and updated as the architecture evolves.
 When reviewing pull requests, prioritize (details in `.github/skills/code-review/SKILL.md`):
 
 1. **Prime/WS contract**: REST prime is mandatory at startup and after every reconnect; WebSocket must never be treated as a source of initial state.
-2. **Async safety**: no blocking calls in the event loop (`asyncio.to_thread` for sync I/O); dispatcher/subscriber tasks must never die silently (`contextlib.suppress` + log); structured concurrency via `asyncio.TaskGroup`.
+2. **Async safety**: no blocking calls in the event loop (`asyncio.to_thread` for sync I/O); dispatcher/subscriber tasks must never die silently (wrap in `try`/`except` and log with `LOG.exception`; reserve `contextlib.suppress` for expected outcomes like cancellation); structured concurrency via `asyncio.TaskGroup`.
 3. **mypy --strict compliance**: no new `Any` without justification, no `# type: ignore` without a comment explaining why.
 4. **Public API stability**: `pybragerone.__all__` (`BragerOneApiClient`, `BragerOneGateway`) and everything documented in `docs/reference/ha_integration.rst` is consumed by the ha-bragerone integration—flag breaking changes.
 5. **Pydantic v2 patterns**: `ConfigDict`, `Field(alias=...)`, `model_validate`; do not introduce v1 idioms.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,7 +174,7 @@ uv run --group docs poe docs-serve   # Serve on localhost:8000
 ```
 
 Documentation includes:
-- `docs/architecture/overview.rst` / `operations.rst`: Architecture and runtime operations
+- `docs/architecture/overview.rst` / `docs/architecture/operations.rst`: Architecture and runtime operations
 - `docs/reference/ha_integration.rst`: HA integration contract (entity descriptors, ParamStore usage)
 - `docs/reference/parameter_format.rst`: Parameter addressing (`P<n>.<chan><idx>`) reference
 - `docs/guides/typing.rst` / `quality.rst` / `tests_guidelines.rst`: Contributor standards

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@
 
 ## Project Overview
 
-**py-bragerone** is an async Python library for the BragerOne cloud/realtime API, primarily designed for Home Assistant integration. It combines REST (aiohttp) with WebSocket (Socket.IO) for realtime updates using an event-driven architecture.
+**py-bragerone** is an async Python library for the BragerOne cloud/realtime API, primarily designed for Home Assistant integration. It combines REST (httpx) with WebSocket (Socket.IO) for realtime updates using an event-driven architecture.
 
 **Key principle**: REST provides snapshots ("prime"), WebSocket provides deltas. Prime is mandatory at startup and after reconnect—WebSocket never provides initial state.
 
@@ -49,10 +49,9 @@
 
 ```
 BragerOneApiClient (REST) ──┐
-                            ├──> BragerOneGateway ──> EventBus ──> ParamStore/StateStore
+                            ├──> BragerOneGateway ──> EventBus ──> ParamStore
 RealtimeManager (WS) ───────┘                                  └──> HA entities/CLI
-uv run --group docs poe docs-build   # Build to docs/_build/html
-uv run --group docs poe docs-serve   # Serve on localhost:8000
+```
 - **BragerOneApiClient** (`src/pybragerone/api/client.py`): Async REST client with token auto-refresh, HTTP cache (ETag/Last-Modified), and Pydantic models
 - **RealtimeManager** (`src/pybragerone/api/ws.py`): Socket.IO wrapper, handles reconnect, namespace `/ws`
 - **BragerOneGateway** (`src/pybragerone/gateway.py`): Orchestrates login → WS connect → modules.connect → subscribe → prime
@@ -144,7 +143,8 @@ Or use VS Code tasks (defined in `.vscode/tasks.json`):
 ### Testing Conventions
 
 - **pytest-asyncio** with `asyncio_mode = "auto"` (see `pyproject.toml`)
-- Mock HTTP via `aioresponses` or monkeypatch `_fetch_text` in catalog tests
+- Mock HTTP via **pytest-httpx** (`httpx_mock` fixture); monkeypatch `_fetch_text` in catalog tests
+- Property-based tests with **Hypothesis** where input space is large
 - Live API tests marked with `@pytest.mark.needs_internet` (see `conftest.py`)
 - Coverage target: run `uv run --group test poe cov` for term-missing report
 
@@ -174,9 +174,10 @@ uv run --group docs poe docs-serve   # Serve on localhost:8000
 ```
 
 Documentation includes:
-- `docs/pybragerone_integration_cheatsheet.rst`: Quick reference for HA integration
-- `docs/pybragerone_integration_notes.rst`: Deep architecture guide with Mermaid diagrams
-- `docs/new_models.rst`: Pydantic model usage examples
+- `docs/architecture/overview.rst` / `operations.rst`: Architecture and runtime operations
+- `docs/reference/ha_integration.rst`: HA integration contract (entity descriptors, ParamStore usage)
+- `docs/reference/parameter_format.rst`: Parameter addressing (`P<n>.<chan><idx>`) reference
+- `docs/guides/typing.rst` / `quality.rst` / `tests_guidelines.rst`: Contributor standards
 
 ## Project-Specific Conventions
 
@@ -270,14 +271,18 @@ These files should be kept in sync and updated as the architecture evolves.
 
 ## Quick References
 
-- **Main docs**: `docs/pybragerone_integration_cheatsheet.rst`
-- **Architecture deep-dive**: `docs/pybragerone_integration_notes.rst`
+- **Architecture**: `docs/architecture/overview.rst`
+- **HA integration contract**: `docs/reference/ha_integration.rst`
 - **API models**: `src/pybragerone/models/api/`
 - **Key examples**: README.rst (ParamStore usage patterns)
 
-## Branch Context
+## Code Review Priorities
 
-**Current branch**: `feature/new-asset-parser`
-**Default branch**: `main`
+When reviewing pull requests, prioritize (details in `.github/skills/code-review/SKILL.md`):
 
-When working on parser features, focus on `src/pybragerone/models/catalog.py` and related tests in `tests/test_catalog_*.py`.
+1. **Prime/WS contract**: REST prime is mandatory at startup and after every reconnect; WebSocket must never be treated as a source of initial state.
+2. **Async safety**: no blocking calls in the event loop (`asyncio.to_thread` for sync I/O); dispatcher/subscriber tasks must never die silently (`contextlib.suppress` + log); structured concurrency via `asyncio.TaskGroup`.
+3. **mypy --strict compliance**: no new `Any` without justification, no `# type: ignore` without a comment explaining why.
+4. **Public API stability**: `pybragerone.__all__` (`BragerOneApiClient`, `BragerOneGateway`) and everything documented in `docs/reference/ha_integration.rst` is consumed by the ha-bragerone integration—flag breaking changes.
+5. **Pydantic v2 patterns**: `ConfigDict`, `Field(alias=...)`, `model_validate`; do not introduce v1 idioms.
+6. **Tests**: new behavior needs tests (pytest-httpx for HTTP, `asyncio_mode=auto`); live-API tests must be marked `@pytest.mark.needs_internet`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -170,7 +170,7 @@ Built with Sphinx + Furo theme:
 
 ```bash
 uv run --group dev --group docs poe docs-build   # Build to docs/_build/html (poe lives in `dev`)
-uv run --group docs poe docs-serve   # Serve on localhost:8000
+uv run --group dev --group docs poe docs-serve   # Serve on localhost:8000 (poe lives in `dev`)
 ```
 
 Documentation includes:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,11 +121,11 @@ uv run --group dev poe pip-audit # Audit dependencies for vulnerabilities
 uv run --group dev poe security  # Run all security checks
 
 # Testing
-uv run --group test poe test     # pytest
-uv run --group test poe cov      # pytest with coverage
+uv run --group dev --group test poe test     # pytest (poe lives in `dev`)
+uv run --group dev --group test poe cov      # pytest with coverage
 
 # Full Validation
-uv run --group dev poe validate  # Run fmt + lint + typecheck + security + test
+uv run --group dev --group test poe validate  # Run fmt + lint + typecheck + security + test (pytest lives in `test`)
 ```
 
 Or use VS Code tasks (defined in `.vscode/tasks.json`):
@@ -146,7 +146,7 @@ Or use VS Code tasks (defined in `.vscode/tasks.json`):
 - Mock HTTP via **pytest-httpx** (`httpx_mock` fixture); in catalog tests fake or mock the injected API client's `get_bytes()` method
 - Property-based tests with **Hypothesis** where input space is large
 - Live API tests marked with `@pytest.mark.needs_internet` (see `conftest.py`)
-- Coverage target: run `uv run --group test poe cov` for term-missing report
+- Coverage target: run `uv run --group dev --group test poe cov` for term-missing report (poe lives in `dev`)
 
 Key test patterns:
 - `tests/test_api.py`: REST client tests (mocked)
@@ -169,7 +169,7 @@ This launches an interactive gateway session showing live parameter updates. Use
 Built with Sphinx + Furo theme:
 
 ```bash
-uv run --group docs poe docs-build   # Build to docs/_build/html
+uv run --group dev --group docs poe docs-build   # Build to docs/_build/html (poe lives in `dev`)
 uv run --group docs poe docs-serve   # Serve on localhost:8000
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -143,7 +143,7 @@ Or use VS Code tasks (defined in `.vscode/tasks.json`):
 ### Testing Conventions
 
 - **pytest-asyncio** with `asyncio_mode = "auto"` (see `pyproject.toml`)
-- Mock HTTP via **pytest-httpx** (`httpx_mock` fixture); monkeypatch `_fetch_text` in catalog tests
+- Mock HTTP via **pytest-httpx** (`httpx_mock` fixture); in catalog tests fake or mock the injected API client's `get_bytes()` method
 - Property-based tests with **Hypothesis** where input space is large
 - Live API tests marked with `@pytest.mark.needs_internet` (see `conftest.py`)
 - Coverage target: run `uv run --group test poe cov` for term-missing report

--- a/.github/instructions/catalog-parser.instructions.md
+++ b/.github/instructions/catalog-parser.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/pybragerone/models/catalog*.py, src/pybragerone/models/menu*.py, src/pybragerone/models/i18n.py, tests/test_catalog_*.py, tests/test_*parser*.py"
+applyTo: "src/pybragerone/models/catalog*.py, src/pybragerone/models/menu*.py, src/pybragerone/models/i18n.py, tests/test_catalog_*.py, tests/test_*parser*.py, tests/test_menu*.py"
 ---
 
 # Asset catalog / tree-sitter parser rules

--- a/.github/instructions/catalog-parser.instructions.md
+++ b/.github/instructions/catalog-parser.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "src/pybragerone/models/catalog*.py, src/pybragerone/models/menu*.py, src/pybragerone/models/i18n.py, tests/test_catalog_*.py"
+---
+
+# Asset catalog / tree-sitter parser rules
+
+`LiveAssetsCatalog` parses live, minified JavaScript from the BragerOne web app. It breaks silently when upstream changes — resilience beats completeness.
+
+1. **Never raise on unexpected JS shape**: parsers return what they can extract and log the rest. A new upstream bundle must not crash the library or HA setup.
+2. **Keep grammar access lazy** (tree-sitter init is expensive and optional at runtime).
+3. **No network in parsing code**: fetching (`_fetch_text`) is separate from parsing; tests monkeypatch `_fetch_text` — keep that seam intact.
+4. **Encoding/i18n**: translation maps are user-facing; preserve Unicode exactly, don't normalize keys.
+5. **Tests**: parser changes require fixtures covering malformed/partial input (see existing `tests/test_catalog_*.py` patterns). Hypothesis property tests are welcome here.
+6. **Size**: `catalog.py` is already ~2k LOC — prefer adding focused modules over growing it further.

--- a/.github/instructions/catalog-parser.instructions.md
+++ b/.github/instructions/catalog-parser.instructions.md
@@ -6,7 +6,7 @@ applyTo: "src/pybragerone/models/catalog*.py, src/pybragerone/models/menu*.py, s
 
 `LiveAssetsCatalog` parses live, minified JavaScript from the BragerOne web app. It breaks silently when upstream changes — resilience beats completeness.
 
-1. **Never raise on unexpected JS shape**: parsers return what they can extract and log the rest. A new upstream bundle must not crash the library or HA setup.
+1. **Never raise on unexpected JS shape from public catalog operations**: parsers return what they can extract and log the rest. A new upstream bundle must not crash the library or HA setup. Internal helpers may raise on malformed shapes when the calling public method catches, logs, and degrades to `None`/partial data (e.g. `_parse_language_config_from_js()` raises; `get_language_config()` converts that to `None`).
 2. **Grammar access**: tree-sitter and `JS_LANGUAGE` are initialized at module import, and `models/__init__.py` imports `LiveAssetsCatalog` eagerly — this is accepted. Parser instances go through the `_TS` wrapper class; keep parsing work inside `_TS` and don't demand laziness refactors in reviews.
 3. **No network in parsing code**: fetching (injected API client's async `get_bytes()`) is separate from parsing; tests fake or mock `get_bytes()` — keep that seam intact.
 4. **Encoding/i18n**: translation maps are user-facing; preserve Unicode exactly, don't normalize keys.

--- a/.github/instructions/catalog-parser.instructions.md
+++ b/.github/instructions/catalog-parser.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/pybragerone/models/catalog*.py, src/pybragerone/models/menu*.py, src/pybragerone/models/i18n.py, tests/test_catalog_*.py"
+applyTo: "src/pybragerone/models/catalog*.py, src/pybragerone/models/menu*.py, src/pybragerone/models/i18n.py, tests/test_catalog_*.py, tests/test_*parser*.py"
 ---
 
 # Asset catalog / tree-sitter parser rules
@@ -7,8 +7,8 @@ applyTo: "src/pybragerone/models/catalog*.py, src/pybragerone/models/menu*.py, s
 `LiveAssetsCatalog` parses live, minified JavaScript from the BragerOne web app. It breaks silently when upstream changes — resilience beats completeness.
 
 1. **Never raise on unexpected JS shape**: parsers return what they can extract and log the rest. A new upstream bundle must not crash the library or HA setup.
-2. **Keep grammar access lazy** (tree-sitter init is expensive and optional at runtime).
-3. **No network in parsing code**: fetching (`_fetch_text`) is separate from parsing; tests monkeypatch `_fetch_text` — keep that seam intact.
+2. **Grammar access**: tree-sitter and `JS_LANGUAGE` are initialized at module import, and `models/__init__.py` imports `LiveAssetsCatalog` eagerly — this is accepted. Parser instances go through the `_TS` wrapper class; keep parsing work inside `_TS` and don't demand laziness refactors in reviews.
+3. **No network in parsing code**: fetching (injected API client's async `get_bytes()`) is separate from parsing; tests fake or mock `get_bytes()` — keep that seam intact.
 4. **Encoding/i18n**: translation maps are user-facing; preserve Unicode exactly, don't normalize keys.
 5. **Tests**: parser changes require fixtures covering malformed/partial input (see existing `tests/test_catalog_*.py` patterns). Hypothesis property tests are welcome here.
 6. **Size**: `catalog.py` is already ~2k LOC — prefer adding focused modules over growing it further.

--- a/.github/instructions/library-core.instructions.md
+++ b/.github/instructions/library-core.instructions.md
@@ -8,7 +8,7 @@ When reviewing or changing library code:
 
 1. **Prime/WS contract**: REST prime is mandatory at startup and after reconnect. Reject any change that treats Socket.IO payloads as initial state or skips re-prime on reconnect.
 2. **Event-loop hygiene**: no blocking I/O in async code — use `asyncio.to_thread()`. Flag `time.sleep`, sync `httpx`/`requests`, or direct file I/O inside coroutines.
-3. **Task lifecycle**: gateway-owned background tasks go through `BragerOneGateway._spawn()` (tracked, cancelled on shutdown); other fire-and-forget tasks use `utils.spawn()`. Dispatch/subscriber loops must suppress and log exceptions, never die silently. `asyncio.TaskGroup` for structured concurrency.
+3. **Task lifecycle**: gateway-owned background tasks go through `BragerOneGateway._spawn()` (tracked, cancelled on shutdown); other fire-and-forget tasks use `utils.spawn()`. Dispatch/subscriber loops must catch and log exceptions (`LOG.exception`), never die silently; reserve `contextlib.suppress` for expected outcomes like cancellation. `asyncio.TaskGroup` for structured concurrency.
 4. **Typing**: mypy strict. New `Any`, `cast()`, or `# type: ignore` need an inline justification comment. Prefer `Protocol` for injectable dependencies.
 5. **Errors**: REST failures raise `ApiError(status, data, headers)` — don't swallow HTTP errors or return bare `None` from the client. ParamStore upserts intentionally soft-fail on malformed keys (`P<n>.<chan><idx>`).
 6. **Pydantic v2 only**: `ConfigDict`, `model_validate`, `Field(alias=...)`. Flag v1 idioms (`Config` class, `.dict()`, `.parse_obj()`).

--- a/.github/instructions/library-core.instructions.md
+++ b/.github/instructions/library-core.instructions.md
@@ -12,6 +12,6 @@ When reviewing or changing library code:
 4. **Typing**: mypy strict. New `Any`, `cast()`, or `# type: ignore` need an inline justification comment. Prefer `Protocol` for injectable dependencies.
 5. **Errors**: REST failures raise `ApiError(status, data, headers)` — don't swallow HTTP errors or return bare `None` from the client. ParamStore upserts intentionally soft-fail on malformed keys (`P<n>.<chan><idx>`).
 6. **Pydantic v2 only**: `ConfigDict`, `model_validate`, `Field(alias=...)`. Flag v1 idioms (`Config` class, `.dict()`, `.parse_obj()`).
-7. **Logging**: `logging.getLogger(__name__)`, no `print`, no logging configuration in library code.
+7. **Logging**: `logging.getLogger(__name__)`, no `print`, no logging configuration in library modules. Entry points are exempt: `cli.py` intentionally uses `print()` for user-facing output and sets up `logging.basicConfig`.
 8. **Public API**: changes to `__init__.py` exports or signatures used by ha-bragerone (see `docs/reference/ha_integration.rst`) are breaking — require explicit PR discussion.
 9. **Docstrings**: Google style, English, on all public objects (ruff `D` rules enforce this).

--- a/.github/instructions/library-core.instructions.md
+++ b/.github/instructions/library-core.instructions.md
@@ -8,7 +8,7 @@ When reviewing or changing library code:
 
 1. **Prime/WS contract**: REST prime is mandatory at startup and after reconnect. Reject any change that treats Socket.IO payloads as initial state or skips re-prime on reconnect.
 2. **Event-loop hygiene**: no blocking I/O in async code — use `asyncio.to_thread()`. Flag `time.sleep`, sync `httpx`/`requests`, or direct file I/O inside coroutines.
-3. **Task lifecycle**: fire-and-forget tasks go through `utils.spawn()`; dispatch/subscriber loops must suppress and log exceptions, never die silently. `asyncio.TaskGroup` for structured concurrency.
+3. **Task lifecycle**: gateway-owned background tasks go through `BragerOneGateway._spawn()` (tracked, cancelled on shutdown); other fire-and-forget tasks use `utils.spawn()`. Dispatch/subscriber loops must suppress and log exceptions, never die silently. `asyncio.TaskGroup` for structured concurrency.
 4. **Typing**: mypy strict. New `Any`, `cast()`, or `# type: ignore` need an inline justification comment. Prefer `Protocol` for injectable dependencies.
 5. **Errors**: REST failures raise `ApiError(status, data, headers)` — don't swallow HTTP errors or return bare `None` from the client. ParamStore upserts intentionally soft-fail on malformed keys (`P<n>.<chan><idx>`).
 6. **Pydantic v2 only**: `ConfigDict`, `model_validate`, `Field(alias=...)`. Flag v1 idioms (`Config` class, `.dict()`, `.parse_obj()`).

--- a/.github/instructions/library-core.instructions.md
+++ b/.github/instructions/library-core.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "src/pybragerone/**/*.py"
+---
+
+# Library core rules (apply to all of src/pybragerone)
+
+When reviewing or changing library code:
+
+1. **Prime/WS contract**: REST prime is mandatory at startup and after reconnect. Reject any change that treats Socket.IO payloads as initial state or skips re-prime on reconnect.
+2. **Event-loop hygiene**: no blocking I/O in async code — use `asyncio.to_thread()`. Flag `time.sleep`, sync `httpx`/`requests`, or direct file I/O inside coroutines.
+3. **Task lifecycle**: fire-and-forget tasks go through `utils.spawn()`; dispatch/subscriber loops must suppress and log exceptions, never die silently. `asyncio.TaskGroup` for structured concurrency.
+4. **Typing**: mypy strict. New `Any`, `cast()`, or `# type: ignore` need an inline justification comment. Prefer `Protocol` for injectable dependencies.
+5. **Errors**: REST failures raise `ApiError(status, data, headers)` — don't swallow HTTP errors or return bare `None` from the client. ParamStore upserts intentionally soft-fail on malformed keys (`P<n>.<chan><idx>`).
+6. **Pydantic v2 only**: `ConfigDict`, `model_validate`, `Field(alias=...)`. Flag v1 idioms (`Config` class, `.dict()`, `.parse_obj()`).
+7. **Logging**: `logging.getLogger(__name__)`, no `print`, no logging configuration in library code.
+8. **Public API**: changes to `__init__.py` exports or signatures used by ha-bragerone (see `docs/reference/ha_integration.rst`) are breaking — require explicit PR discussion.
+9. **Docstrings**: Google style, English, on all public objects (ruff `D` rules enforce this).

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -6,8 +6,8 @@ applyTo: "tests/**/*.py"
 
 1. **Async**: `asyncio_mode = "auto"` — async test functions need no marker; do not add event-loop fixtures.
 2. **HTTP mocking**: use **pytest-httpx** (`httpx_mock` fixture), not `aioresponses` (the library uses httpx, not aiohttp).
-3. **No network by default**: tests must pass offline. Anything hitting the real API needs `@pytest.mark.needs_internet`.
+3. **No network by default**: tests must pass offline. Anything hitting the real API needs `@pytest.mark.needs_internet` (skipped by default; opt in with `pytest --run-live`).
 4. **Determinism**: no wall-clock sleeps; use `asyncio.Event`/queues to synchronize. Inject clocks for time logic (freezegun is not a project dependency — don't introduce it without adding it first).
 5. **Coverage**: pre-push gate is `--cov-fail-under=80`; new modules should ship with meaningful tests, not just line coverage.
 6. **Style**: same ruff/mypy rules as `src/`; fixtures in `conftest.py` stay minimal.
-7. **Naming**: `tests/test_<area>_<aspect>.py`, flat layout.
+7. **Naming**: `tests/test_*.py`, flat layout (e.g. `test_api.py`, `test_catalog_parser.py`).

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "tests/**/*.py"
+---
+
+# Test suite rules
+
+1. **Async**: `asyncio_mode = "auto"` — async test functions need no marker; do not add event-loop fixtures.
+2. **HTTP mocking**: use **pytest-httpx** (`httpx_mock` fixture), not `aioresponses` (the library uses httpx, not aiohttp).
+3. **No network by default**: tests must pass offline. Anything hitting the real API needs `@pytest.mark.needs_internet`.
+4. **Determinism**: no wall-clock sleeps; use `asyncio.Event`/queues to synchronize. Freezegun or injected clocks for time logic.
+5. **Coverage**: pre-push gate is `--cov-fail-under=80`; new modules should ship with meaningful tests, not just line coverage.
+6. **Style**: same ruff/mypy rules as `src/`; fixtures in `conftest.py` stay minimal.
+7. **Naming**: `tests/test_<area>_<aspect>.py`, flat layout.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -7,7 +7,7 @@ applyTo: "tests/**/*.py"
 1. **Async**: `asyncio_mode = "auto"` — async test functions need no marker; do not add event-loop fixtures.
 2. **HTTP mocking**: use **pytest-httpx** (`httpx_mock` fixture), not `aioresponses` (the library uses httpx, not aiohttp).
 3. **No network by default**: tests must pass offline. Anything hitting the real API needs `@pytest.mark.needs_internet`.
-4. **Determinism**: no wall-clock sleeps; use `asyncio.Event`/queues to synchronize. Freezegun or injected clocks for time logic.
+4. **Determinism**: no wall-clock sleeps; use `asyncio.Event`/queues to synchronize. Inject clocks for time logic (freezegun is not a project dependency — don't introduce it without adding it first).
 5. **Coverage**: pre-push gate is `--cov-fail-under=80`; new modules should ship with meaningful tests, not just line coverage.
 6. **Style**: same ruff/mypy rules as `src/`; fixtures in `conftest.py` stay minimal.
 7. **Naming**: `tests/test_<area>_<aspect>.py`, flat layout.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -10,7 +10,7 @@ Review procedure for pull requests to this library. Work through every section; 
 ## 1. Correctness — data-flow contract
 
 - [ ] REST **prime** still happens at startup and after every reconnect; WebSocket is deltas-only.
-- [ ] `EventBus` subscribers can't be killed by an unhandled exception (suppress + log).
+- [ ] `EventBus` subscribers can't be killed by an unhandled exception (catch and log; suppress only expected outcomes like cancellation).
 - [ ] Token refresh in `BragerOneApiClient` is transparent; no caller-side token management added.
 - [ ] Meta-only events (`value=None`) handling unchanged — `ParamStore` ignores them by design.
 
@@ -58,7 +58,7 @@ Review procedure for pull requests to this library. Work through every section; 
 
 ## Stack awareness
 
-- Before flagging stale references or inconsistencies, check whether the PR belongs to a stack (read the PR's `stack` object via the GitHub MCP server). If it does, fetch the stack's PR list and review the layer in the context of the whole stack — the fix may already exist in an upper layer.
+- Before flagging stale references or inconsistencies, check whether the PR belongs to a stack: look for "Stacked on #NNN" links or cross-referenced PRs in the PR body and timeline, and fetch those PRs via the GitHub MCP server. If the PR is part of a stack, review the layer in the context of the whole stack — the fix may already exist in a linked layer.
 
 ## How to report
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -17,7 +17,7 @@ Review procedure for pull requests to this library. Work through every section; 
 ## 2. Async & concurrency
 
 - [ ] No blocking calls in the event loop (sync httpx/requests, `time.sleep`, file I/O in coroutines).
-- [ ] New background tasks use `utils.spawn()` or `asyncio.TaskGroup`.
+- [ ] New background tasks: gateway-owned work uses `BragerOneGateway._spawn()` (tracked, cancelled on shutdown); other fire-and-forget tasks use `utils.spawn()` or `asyncio.TaskGroup`.
 - [ ] Mutable shared state is protected (locks/immutable/actor-style) — do not rely on the GIL.
 
 ## 3. Typing & style gates (CI runs these — flag what it can't catch)

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,58 @@
+# Code Review — py-bragerone
+
+Review procedure for pull requests to this library. Work through every section; only comment on real issues, with file/line references and a concrete suggested fix.
+
+## 1. Correctness — data-flow contract
+
+- [ ] REST **prime** still happens at startup and after every reconnect; WebSocket is deltas-only.
+- [ ] `EventBus` subscribers can't be killed by an unhandled exception (suppress + log).
+- [ ] Token refresh in `BragerOneApiClient` is transparent; no caller-side token management added.
+- [ ] Meta-only events (`value=None`) handling unchanged — `ParamStore` ignores them by design.
+
+## 2. Async & concurrency
+
+- [ ] No blocking calls in the event loop (sync httpx/requests, `time.sleep`, file I/O in coroutines).
+- [ ] New background tasks use `utils.spawn()` or `asyncio.TaskGroup`.
+- [ ] Mutable shared state is protected (locks/immutable/actor-style) — do not rely on the GIL.
+
+## 3. Typing & style gates (CI runs these — flag what it can't catch)
+
+- [ ] mypy `--strict`-clean; new `Any`/`cast`/`type: ignore` justified in a comment.
+- [ ] Ruff: line length 130, Google docstrings on new public objects, import order.
+- [ ] Pydantic v2 idioms only; `ApiResponse[T]` generic reused for new endpoints.
+- [ ] English-only code, comments, docstrings.
+
+## 4. Public API & versioning
+
+- [ ] `pybragerone.__all__` and signatures used by ha-bragerone (see `docs/reference/ha_integration.rst`) unchanged, or the breaking change is explicitly called out in the PR description with a migration note.
+- [ ] No version string edited in `pyproject.toml` (hatch-vcs/CalVer from git tags).
+- [ ] New dependencies justified (license, maintenance, wheel availability) and added via uv.
+
+## 5. Error handling
+
+- [ ] REST errors surface as `ApiError` with status/data/headers.
+- [ ] No broad `except Exception` without logging; no silent `pass`.
+
+## 6. Tests
+
+- [ ] New behavior covered; HTTP mocked with pytest-httpx; suite passes offline.
+- [ ] Live-API tests marked `@pytest.mark.needs_internet`.
+- [ ] Parser changes (catalog/tree-sitter) include malformed-input fixtures.
+- [ ] Coverage gate (80%) not weakened.
+
+## 7. Security & secrets
+
+- [ ] No credentials, tokens, or personal account data in code, tests, fixtures, or logs.
+- [ ] Secrets never logged — check debug logging of auth payloads and WS frames.
+- [ ] New HTTP surface validates/sanitizes server data through Pydantic models.
+
+## 8. Docs
+
+- [ ] Public behavior changes reflected in `docs/` (Sphinx builds with `-W` in CI).
+- [ ] README.rst examples still valid if touched surface is covered there.
+
+## How to report
+
+- One comment per issue, severity-tagged: **blocker** (contract break, data loss, crash), **major** (CI gate, typing, missing tests), **minor** (style, docs, naming).
+- Prefer suggesting the smallest change that fits existing patterns over proposing new abstractions.
+- If the PR mentions an issue, use the GitHub MCP server to read it and verify the change actually addresses it.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -58,6 +58,6 @@ Review procedure for pull requests to this library. Work through every section; 
 
 ## How to report
 
-- One comment per issue; start the comment with the severity in plain text — blocker (contract break, data loss, crash), major (CI gate, typing, missing tests), or minor (style, docs, naming) — so impact is clear even though review comment formatting cannot be customized.
+- One comment per issue. Use severity to triage what you report — blocker (contract break, data loss, crash), major (CI gate, typing, missing tests), minor (style, docs, naming) — and report blockers/majors first. Treat this as prioritization guidance, not a required comment format.
 - Prefer suggesting the smallest change that fits existing patterns over proposing new abstractions.
 - If the PR mentions an issue, use the GitHub MCP server to read it and verify the change actually addresses it.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -36,7 +36,7 @@ Review procedure for pull requests to this library. Work through every section; 
 ## 5. Error handling
 
 - [ ] REST errors surface as `ApiError` with status/data/headers.
-- [ ] No broad `except Exception` without logging; no silent `pass`.
+- [ ] No broad `except Exception` without logging; no silent `pass` — except explicitly documented soft-fail contracts (e.g. `ParamStore.upsert()` returns `None` on malformed keys by design).
 
 ## 6. Tests
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -58,6 +58,6 @@ Review procedure for pull requests to this library. Work through every section; 
 
 ## How to report
 
-- One comment per issue, severity-tagged: **blocker** (contract break, data loss, crash), **major** (CI gate, typing, missing tests), **minor** (style, docs, naming).
+- One comment per issue; start the comment with the severity in plain text — blocker (contract break, data loss, crash), major (CI gate, typing, missing tests), or minor (style, docs, naming) — so impact is clear even though review comment formatting cannot be customized.
 - Prefer suggesting the smallest change that fits existing patterns over proposing new abstractions.
 - If the PR mentions an issue, use the GitHub MCP server to read it and verify the change actually addresses it.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -17,7 +17,7 @@ Review procedure for pull requests to this library. Work through every section; 
 ## 2. Async & concurrency
 
 - [ ] No blocking calls in the event loop (sync httpx/requests, `time.sleep`, file I/O in coroutines).
-- [ ] New background tasks: gateway-owned work uses `BragerOneGateway._spawn()` (tracked, cancelled on shutdown); other fire-and-forget tasks use `utils.spawn()` or `asyncio.TaskGroup`.
+- [ ] New background tasks: gateway-owned work uses `BragerOneGateway._spawn()` (tracked, cancelled on shutdown); other detached work uses `utils.spawn()`. `asyncio.TaskGroup` is for structured concurrency only — its scope waits for all child tasks, so it is not a fire-and-forget mechanism.
 - [ ] Mutable shared state is protected (locks/immutable/actor-style) — do not rely on the GIL.
 
 ## 3. Typing & style gates (CI runs these — flag what it can't catch)

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-review
+description: Review checklist for py-bragerone pull requests. Use when reviewing PRs to verify the REST prime / WebSocket delta contract, async safety, mypy strict compliance, public API stability, tests, and security.
+---
+
 # Code Review — py-bragerone
 
 Review procedure for pull requests to this library. Work through every section; only comment on real issues, with file/line references and a concrete suggested fix.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -56,6 +56,10 @@ Review procedure for pull requests to this library. Work through every section; 
 - [ ] Public behavior changes reflected in `docs/` (Sphinx builds with `-W` in CI).
 - [ ] README.rst examples still valid if touched surface is covered there.
 
+## Stack awareness
+
+- Before flagging stale references or inconsistencies, check whether the PR belongs to a stack (read the PR's `stack` object via the GitHub MCP server). If it does, fetch the stack's PR list and review the layer in the context of the whole stack — the fix may already exist in an upper layer.
+
 ## How to report
 
 - One comment per issue. Use severity to triage what you report — blocker (contract break, data loss, crash), major (CI gate, typing, missing tests), minor (style, docs, naming) — and report blockers/majors first. Treat this as prioritization guidance, not a required comment format.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Pre-commit hooks exist; a coverage gate (`--cov-fail-under=80`) runs on pre-push
 
 ## Architecture in one paragraph
 
-REST **primes** the state (snapshots); WebSocket delivers **deltas only** and never replays state — after every reconnect you must re-subscribe and re-prime. `BragerOneApiClient` (`api/client.py`, httpx, token auto-refresh, ETag cache) and `RealtimeManager` (`api/ws.py`, python-socketio `/ws` namespace) feed `BragerOneGateway` (`gateway.py`), which publishes `ParamUpdate` events on the `EventBus` (`models/events.py`) into `ParamStore` (`models/param.py`). `LiveAssetsCatalog` (`models/catalog.py`) parses live JS web-app assets with tree-sitter for menus/i18n/permissions — used at config time, not hot runtime.
+REST **primes** the state (snapshots); WebSocket delivers **deltas only** and never replays state — after every reconnect you must re-subscribe and re-prime. `BragerOneApiClient` (`src/pybragerone/api/client.py`, httpx, token auto-refresh, ETag cache) and `RealtimeManager` (`src/pybragerone/api/ws.py`, python-socketio `/ws` namespace) feed `BragerOneGateway` (`src/pybragerone/gateway.py`), which publishes `ParamUpdate` events on the `EventBus` (`src/pybragerone/models/events.py`) into `ParamStore` (`src/pybragerone/models/param.py`). `LiveAssetsCatalog` (`src/pybragerone/models/catalog.py`) parses live JS web-app assets with tree-sitter for menus/i18n/permissions — used at config time, not hot runtime.
 
 Parameter addressing: `P<n>.<chan><idx>` (channels: `v` value, `s` status bitmask, `u` unit/enum, `n`/`x` min/max, `t` type).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,8 @@ uv sync --group dev --group test --group docs --locked   # full environment
 uv run --group dev poe fmt        # ruff format
 uv run --group dev poe lint       # ruff check --fix
 uv run --group dev poe typecheck  # mypy --strict
-uv run --group test poe test      # pytest
-uv run --group test poe cov       # pytest + coverage
+uv run --group dev --group test poe test      # pytest (poe lives in `dev`)
+uv run --group dev --group test poe cov       # pytest + coverage
 uv run --group dev --group test poe validate   # fmt + lint + typecheck + security + test (needs both groups: pytest lives in `test`)
 uv build                          # wheel + sdist
 ```
@@ -49,7 +49,7 @@ Parameter addressing: `P<n>.<chan><idx>` (channels: `v` value, `s` status bitmas
 
 ## Docs
 
-Sphinx + Furo; `uv run --group docs poe docs-build`. Sphinx runs with `-W` in CI — warnings are errors. Update `docs/` when changing public behavior.
+Sphinx + Furo; `uv run --group dev --group docs poe docs-build` (poe lives in `dev`). Sphinx runs with `-W` in CI — warnings are errors. Update `docs/` when changing public behavior.
 
 ## CI gates (`.github/workflows/ci.yml`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md — py-bragerone
+
+Async Python library for the BragerOne cloud/realtime API (REST + Socket.IO), designed primarily as the data layer for the `ha-bragerone` Home Assistant integration.
+
+## Project shape
+
+- **Layout**: src-layout, single package `src/pybragerone/`, tests in `tests/` (flat `test_*.py`).
+- **Python**: `>=3.13.2,<3.15` (CI tests on 3.13).
+- **Dependencies**: **uv** (`uv.lock` committed). Groups: `dev`, `test`, `docs`, `security`, `fuzz`.
+- **Build**: hatchling + **hatch-vcs** — version is CalVer derived from git tags; never hardcode a version in `pyproject.toml`.
+
+## Common commands
+
+```bash
+uv sync --group dev --group test --group docs --locked   # full environment
+uv run --group dev poe fmt        # ruff format
+uv run --group dev poe lint       # ruff check --fix
+uv run --group dev poe typecheck  # mypy --strict
+uv run --group test poe test      # pytest
+uv run --group test poe cov       # pytest + coverage
+uv run --group dev poe validate   # fmt + lint + typecheck + security + test
+uv build                          # wheel + sdist
+```
+
+Pre-commit hooks exist; a coverage gate (`--cov-fail-under=80`) runs on pre-push.
+
+## Architecture in one paragraph
+
+REST **primes** the state (snapshots); WebSocket delivers **deltas only** and never replays state — after every reconnect you must re-subscribe and re-prime. `BragerOneApiClient` (`api/client.py`, httpx, token auto-refresh, ETag cache) and `RealtimeManager` (`api/ws.py`, python-socketio `/ws` namespace) feed `BragerOneGateway` (`gateway.py`), which publishes `ParamUpdate` events on the `EventBus` (`models/events.py`) into `ParamStore` (`models/param.py`). `LiveAssetsCatalog` (`models/catalog.py`) parses live JS web-app assets with tree-sitter for menus/i18n/permissions — used at config time, not hot runtime.
+
+Parameter addressing: `P<n>.<chan><idx>` (channels: `v` value, `s` status bitmask, `u` unit/enum, `n`/`x` min/max, `t` type).
+
+## Non-negotiable conventions
+
+1. **English only** in code, comments, docstrings.
+2. **mypy --strict** must pass (pydantic plugin enabled). No `Any`, no `# type: ignore` without justification.
+3. **Ruff** (`line-length = 130`, rules `E,F,W,I,D,UP,RUF,SIM,B`, Google-style docstrings) must pass; run `poe fix` before committing.
+4. **Async-first**: never block the event loop; `asyncio.to_thread()` for sync work; `asyncio.TaskGroup` for structured concurrency; long-lived dispatch tasks must not die silently (suppress + log).
+5. **Pydantic v2** for DTOs (`ConfigDict`, `Field(alias=...)`, generics like `ApiResponse[T]`).
+6. **Public API** is `pybragerone.__all__` = `["BragerOneApiClient", "BragerOneGateway"]` plus what `docs/reference/ha_integration.rst` documents. Breaking it breaks the HA integration — call it out explicitly in PRs.
+7. **Logging**: stdlib `logging.getLogger(__name__)`; the library root attaches a `NullHandler` — never configure logging in library code.
+
+## Testing
+
+- pytest with `asyncio_mode = "auto"`; mock HTTP with **pytest-httpx** (`httpx_mock`).
+- Live-API tests must be marked `@pytest.mark.needs_internet`.
+- Hypothesis for property-based tests; fuzz harness lives in `fuzz/` (atheris).
+- Parser resilience (catalog/tree-sitter) is heavily tested in `tests/test_catalog_*.py` — keep it that way; upstream JS assets change without notice.
+
+## Docs
+
+Sphinx + Furo; `uv run --group docs poe docs-build`. Sphinx runs with `-W` in CI — warnings are errors. Update `docs/` when changing public behavior.
+
+## CI gates (`.github/workflows/ci.yml`)
+
+gitleaks → dependency-review → pip-audit → ruff (check + format) → mypy → pytest (3.13) → Sphinx `-W` → hatch build. CodeQL and OpenSSF Scorecard run separately.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,4 @@ Sphinx + Furo; `uv run --group docs poe docs-build`. Sphinx runs with `-W` in CI
 
 ## CI gates (`.github/workflows/ci.yml`)
 
-gitleaks → dependency-review → pip-audit → ruff (check + format) → mypy → pytest (3.13) → Sphinx `-W` → hatch build. CodeQL and OpenSSF Scorecard run separately.
+gitleaks → dependency-review → ruff (check + format) → mypy → pytest (3.13) → Sphinx `-W` → hatch build. pip-audit runs as an artifact-producing advisory job (`continue-on-error: true`, not a blocking gate); CodeQL and OpenSSF Scorecard run separately.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,4 @@ Sphinx + Furo; `uv run --group docs poe docs-build`. Sphinx runs with `-W` in CI
 
 ## CI gates (`.github/workflows/ci.yml`)
 
-gitleaks → dependency-review → ruff (check + format) → mypy → pytest (3.13) → Sphinx `-W` → hatch build. pip-audit runs as an artifact-producing advisory job (`continue-on-error: true`, not a blocking gate); CodeQL and OpenSSF Scorecard run separately.
+Independent jobs run in parallel: `secrets` (gitleaks), `dependency-review`, `security`, `quality` (ruff check + format, mypy), `tests` (pytest 3.13), `docs-verify` (Sphinx `-W`). `build` (hatch) gates on all of them except `dependency-review` (`needs: [secrets, security, quality, tests, docs-verify]`). pip-audit runs as an artifact-producing advisory job (`continue-on-error: true`, not a blocking gate); CodeQL and OpenSSF Scorecard run separately.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Parameter addressing: `P<n>.<chan><idx>` (channels: `v` value, `s` status bitmas
 1. **English only** in code, comments, docstrings.
 2. **mypy --strict** must pass (pydantic plugin enabled). No `Any`, no `# type: ignore` without justification.
 3. **Ruff** (`line-length = 130`, rules `E,F,W,I,D,UP,RUF,SIM,B`, Google-style docstrings) must pass; run `poe fix` before committing.
-4. **Async-first**: never block the event loop; `asyncio.to_thread()` for sync work; `asyncio.TaskGroup` for structured concurrency; long-lived dispatch tasks must not die silently (suppress + log).
+4. **Async-first**: never block the event loop; `asyncio.to_thread()` for sync work; `asyncio.TaskGroup` for structured concurrency; long-lived dispatch tasks must not die silently (catch and log with `LOG.exception`; reserve `contextlib.suppress` for expected outcomes like cancellation).
 5. **Pydantic v2** for DTOs (`ConfigDict`, `Field(alias=...)`, generics like `ApiResponse[T]`).
 6. **Public API** is `pybragerone.__all__` = `["BragerOneApiClient", "BragerOneGateway"]` plus what `docs/reference/ha_integration.rst` documents. Breaking it breaks the HA integration — call it out explicitly in PRs.
 7. **Logging**: stdlib `logging.getLogger(__name__)`; the library root attaches a `NullHandler` — never configure logging in library code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Async Python library for the BragerOne cloud/realtime API (REST + Socket.IO), de
 
 - **Layout**: src-layout, single package `src/pybragerone/`, tests in `tests/` (flat `test_*.py`).
 - **Python**: `>=3.13.2,<3.15` (CI tests on 3.13).
-- **Dependencies**: **uv** (`uv.lock` committed). Groups: `dev`, `test`, `docs`, `security`, `fuzz`.
+- **Dependencies**: **uv** (`uv.lock` committed). Groups: `dev` (includes security tools: bandit, semgrep, pip-audit), `test`, `docs`, `fuzz`.
 - **Build**: hatchling + **hatch-vcs** — version is CalVer derived from git tags; never hardcode a version in `pyproject.toml`.
 
 ## Common commands
@@ -18,7 +18,7 @@ uv run --group dev poe lint       # ruff check --fix
 uv run --group dev poe typecheck  # mypy --strict
 uv run --group test poe test      # pytest
 uv run --group test poe cov       # pytest + coverage
-uv run --group dev poe validate   # fmt + lint + typecheck + security + test
+uv run --group dev --group test poe validate   # fmt + lint + typecheck + security + test (needs both groups: pytest lives in `test`)
 uv build                          # wheel + sdist
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Parameter addressing: `P<n>.<chan><idx>` (channels: `v` value, `s` status bitmas
 4. **Async-first**: never block the event loop; `asyncio.to_thread()` for sync work; `asyncio.TaskGroup` for structured concurrency; long-lived dispatch tasks must not die silently (catch and log with `LOG.exception`; reserve `contextlib.suppress` for expected outcomes like cancellation).
 5. **Pydantic v2** for DTOs (`ConfigDict`, `Field(alias=...)`, generics like `ApiResponse[T]`).
 6. **Public API** is `pybragerone.__all__` = `["BragerOneApiClient", "BragerOneGateway"]` plus what `docs/reference/ha_integration.rst` documents. Breaking it breaks the HA integration — call it out explicitly in PRs.
-7. **Logging**: stdlib `logging.getLogger(__name__)`; the library root attaches a `NullHandler` — never configure logging in library code.
+7. **Logging**: stdlib `logging.getLogger(__name__)`; the library root attaches a `NullHandler` — never configure logging in library modules. Entry points are exempt: `cli.py` intentionally uses `print()` and `logging.basicConfig`.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Refresh `.github/copilot-instructions.md`: fix stale references (aiohttp → httpx, aioresponses → pytest-httpx), repair broken architecture diagram, point to current `docs/` files, add Code Review Priorities section
- Add `AGENTS.md` describing project shape, uv/poe commands, prime/WS contract, and non-negotiable conventions
- Add path-specific instructions in `.github/instructions/` (library core, tree-sitter catalog parser, tests)
- Add review-focused agent skill `.github/skills/code-review/SKILL.md` with a severity-tagged checklist (prime/WS contract, async safety, mypy strict, public API stability, tests, security)

## Stack
- #249 is stacked on this PR: it fixes the stale `docs/guides/tests_guidelines.rst` mocking guidance referenced here and adds the `--run-live` opt-in that makes the `needs_internet` convention enforceable.

## Test plan
- [ ] Open a test PR and request Copilot code review; verify comments reference the `code-review` skill / instructions (attributions under comments)
- [ ] Verify no CI regressions (markdown-only change)