### PR TITLE
test+docs: align testing setup with actual conventions

### DIFF
--- a/docs/guides/tests_guidelines.rst
+++ b/docs/guides/tests_guidelines.rst
@@ -6,18 +6,19 @@ This doc explains how we test the frontend parsers and the online API.
 Local unit tests
 ----------------
 
-- Use pytest + pytest-asyncio.
-- Mock HTTP (no network) by monkeypatching ``_fetch_text`` and ``_autodetect_index_url``.
+- Use pytest + pytest-asyncio (``asyncio_mode = "auto"``).
+- Mock HTTP (no network) with **pytest-httpx** (``httpx_mock`` fixture); in catalog tests, fake or mock the injected API client's ``get_bytes()`` method.
 
 Example layout::
 
    tests/
-     test_utils.py
-     test_resolver.py
-     test_parser.py
-     test_parser_i18n.py
      test_api.py
-     test_api_live.py
+     test_api_get_bytes_retry.py
+     test_catalog_permissions.py
+     test_parser_resilience.py
+     test_i18n_parser.py
+     test_param_map_parser.py
+     test_gateway_prime_reconnect.py
      conftest.py
 
 conftest.py (live toggle + session)

--- a/docs/guides/tests_guidelines.rst
+++ b/docs/guides/tests_guidelines.rst
@@ -24,6 +24,8 @@ Example layout::
 conftest.py (live toggle + session)
 -----------------------------------
 
+Tests that need real network access are marked ``@pytest.mark.needs_internet`` and are skipped by default; opt in with ``pytest --run-live`` or ``RUN_LIVE_TESTS=1``.
+
 .. literalinclude:: ../../tests/conftest.py
    :language: python
    :caption: conftest.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,29 @@ This module contains pytest configuration settings and shared fixtures
 used across the test suite.
 """
 
+import os
+
 import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the --run-live option for tests that require internet access."""
+    parser.addoption(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help="run tests marked needs_internet (require network access)",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip needs_internet tests unless --run-live or RUN_LIVE_TESTS=1 is given."""
+    if config.getoption("--run-live") or os.environ.get("RUN_LIVE_TESTS") == "1":
+        return
+    skip_live = pytest.mark.skip(reason="requires internet; pass --run-live or set RUN_LIVE_TESTS=1")
+    for item in items:
+        if "needs_internet" in item.keywords:
+            item.add_marker(skip_live)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- Fix stale HTTP-mocking guidance in `docs/guides/tests_guidelines.rst` (pytest-httpx + `get_bytes()` seam instead of removed `_fetch_text`/`_autodetect_index_url`)
- Refresh the example test layout with actual test file names
- Enforce the `needs_internet` marker: skipped by default via a conftest collection hook, opt in with `pytest --run-live` or `RUN_LIVE_TESTS=1` (addresses Copilot review on #248)

Stacked on #248.

## Test plan
- [x] `uv run mypy tests/conftest.py` clean
- [x] `uv run pytest -q` passes offline