### PR TITLE
Close gaps toward OpenSSF silver and baseline badges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
 
     steps:
       - name: Checkout tag
@@ -56,6 +57,29 @@ jobs:
           ls -lh dist/
           uv tool run twine check dist/*
 
+      - name: Generate SHA256 checksums
+        shell: bash
+        run: |
+          cd dist
+          sha256sum *.whl *.tar.gz > SHA256SUMS
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: ./
+          format: cyclonedx-json
+          output-file: dist/sbom.cyclonedx.json
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/*.whl
+
+      - name: Attest sdist provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/*.tar.gz
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -79,3 +103,5 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/SHA256SUMS
+            dist/sbom.cyclonedx.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,12 @@ Thanks for helping improve py-bragerone.
 
 The project uses GitHub Issues and Pull Requests for discussion and review.
 
+## Requirements for acceptable contributions
+
+- **Tests**: major new functionality MUST come with tests; bug fixes should add a regression test where practical. All tests must pass offline (`pytest --run-live` is opt-in only).
+- **Style**: `ruff format` + `ruff check` clean, `mypy --strict` clean, English only in code and docs, Google-style docstrings. Run `uv run --group dev --group test poe validate` before pushing.
+- **DCO**: every commit MUST be signed off (`git commit -s`) to certify the [Developer Certificate of Origin](https://developercertificate.org/) — i.e. that you are legally authorized to contribute the change under the project's MIT license.
+
 ## Development setup
 
 ```bash

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,23 @@
+# Governance
+
+## Model
+
+py-bragerone is a single-maintainer project: the owner (@marpi82) makes all final decisions on direction, releases, and dispute resolution (benevolent-dictator model). This may evolve if regular co-maintainers join.
+
+## Roles and responsibilities
+
+| Role | Who | Responsibilities |
+| --- | --- | --- |
+| Maintainer / owner | @marpi82 | Reviews and merges PRs, triages issues, cuts releases, owns security response (see `SECURITY.md`), manages repository settings and access |
+| Contributors | anyone | Open issues and PRs, follow `CONTRIBUTING.md` and the code of conduct |
+
+Only the maintainer has access to sensitive resources (repository settings, PyPI trusted publishing, security advisories).
+
+## Access changes
+
+Escalated permissions (e.g. collaborator with write access) are granted only after a track record of reviewed contributions, and are reviewed when activity changes.
+
+## Decisions
+
+- Day-to-day: decided in GitHub issues/PR discussions.
+- Breaking changes to the public API (`pybragerone.__all__`, documented in `docs/reference/ha_integration.rst`) require an explicit maintainer decision recorded in the PR.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,23 @@
 
 ## Reporting Security Vulnerabilities
 
-If you discover a security vulnerability in py-bragerone, please report it by emailing marpi82.dev@google.com. Please do not create a public GitHub issue for security vulnerabilities.
+If you discover a security vulnerability in py-bragerone, please report it privately:
+
+- **Preferred**: [GitHub private vulnerability reporting](https://github.com/marpi82/py-bragerone/security/advisories/new)
+- **Alternative**: email marpi82.dev@google.com
+
+Please do not create a public GitHub issue for security vulnerabilities.
+
+## Coordinated Vulnerability Disclosure
+
+- **Acknowledgement**: within 3 business days.
+- **Initial assessment and severity triage**: within 14 days.
+- **Fix or mitigation**: targeted within 90 days of confirmation, depending on severity and complexity.
+- **Disclosure**: coordinated with the reporter; a GitHub Security Advisory is published once a fix is released (or when we mutually agree). Reporters are credited in the advisory unless they prefer otherwise.
+
+## Supported Versions
+
+Only the **latest release** receives security fixes; there are no backports to older versions. When a release line stops receiving security updates, it is simply superseded by the newest release — upgrade to stay supported.
 
 ## Dependency Security
 
@@ -67,4 +83,4 @@ Security exceptions should be reviewed:
 
 ## Contact
 
-For security concerns, contact: marpi82.dev@google.com
+For security concerns, use [GitHub private vulnerability reporting](https://github.com/marpi82/py-bragerone/security/advisories/new) or contact: marpi82.dev@google.com

--- a/docs/guides/getting_started.rst
+++ b/docs/guides/getting_started.rst
@@ -265,10 +265,23 @@ Common tasks::
 
 Release flow (suggestion)::
 
-  1. Bump version in pyproject
-  2. Tag & GitHub release
-  3. Build:  python -m build
-  4. Publish: twine upload dist/*   (or TestPyPI first)
+  1. Tag with CalVer (``git tag 2026.8.1``) & push the tag
+  2. The release workflow builds, attests, and publishes to PyPI
+  3. GitHub Release is created with dists, ``SHA256SUMS`` and an SBOM
+
+Verifying releases
+------------------
+
+Each GitHub Release ships ``SHA256SUMS`` and a CycloneDX SBOM
+(``sbom.cyclonedx.json``), and the built distributions carry Sigstore
+build-provenance attestations. To verify integrity and authenticity::
+
+  gh release download <tag> -R marpi82/py-bragerone
+  sha256sum -c SHA256SUMS
+  gh attestation verify py_bragerone-<version>-py3-none-any.whl -R marpi82/py-bragerone
+
+The attestation proves the artifact was built by this repository's
+release workflow from the tagged commit.
 
 Contributing
 ------------

--- a/docs/guides/roadmap.rst
+++ b/docs/guides/roadmap.rst
@@ -1,0 +1,28 @@
+Roadmap
+=======
+
+Direction for the next ~12 months. This is a statement of intent, not a
+commitment — items may move or drop as upstream (BragerOne web app,
+Home Assistant) evolves.
+
+Planned
+-------
+
+- **Stabilize the public API** (``BragerOneApiClient``, ``BragerOneGateway``,
+  ``ParamStore``) and graduate from Alpha status.
+- **Keep pace with upstream assets**: the live catalog parser depends on
+  BragerOne's web-app bundles; ongoing work is resilience to upstream changes
+  (tree-sitter grammars, menu/i18n shapes).
+- **Home Assistant integration parity**: extend ``ha-bragerone`` coverage of
+  the parameter catalog as new modules/panels are discovered.
+- **Release cadence**: CalVer releases as changes land; security fixes as
+  soon as practical.
+
+Not planned
+-----------
+
+- Official ``climate`` platform logic in the library (belongs to the HA
+  integration layer).
+- Support for Python < 3.13.
+- Local (LAN) protocol reverse-engineering — the library targets the
+  BragerOne cloud API only.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,6 +85,7 @@ Key Features
    guides/typing
    guides/tests_guidelines
    guides/quality
+   guides/roadmap
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
## Summary
Prepares the repository for OpenSSF Best Practices **silver** and **baseline-1/-2** self-certification (project [#13994](https://www.bestpractices.dev/en/projects/13994)):

- **SECURITY.md**: CVD policy with response timeframes (ack 3 days / triage 14 / fix target 90), supported versions, GitHub private vulnerability reporting — covers baseline VM-01.01/VM-03.01, DO-04.01/05.01
- **CONTRIBUTING.md**: DCO sign-off (silver dco, baseline-2 LE-01.01), mandatory tests for major features (silver test_policy_mandated)
- **GOVERNANCE.md**: roles & responsibilities (silver governance/roles_responsibilities, baseline-2 GV-01.x)
- **docs**: roadmap (silver documentation_roadmap), release verification guide (baseline-3 DO-03.x)
- **release.yml**: SHA256SUMS + CycloneDX SBOM + Sigstore provenance attestations (baseline-2 BR-06.01, silver signed_releases)

## Test plan
- [x] `sphinx-build -W` passes
- [ ] Next release produces SHA256SUMS, SBOM, attestations on the release page
- [ ] Enable branch protection + private vulnerability reporting (done via API alongside this PR)