### PR TITLE
docs(readme): add in-progress silver/baseline badge shields

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,6 +17,14 @@ Only the maintainer has access to sensitive resources (repository settings, PyPI
 
 Escalated permissions (e.g. collaborator with write access) are granted only after a track record of reviewed contributions, and are reviewed when activity changes.
 
+## Continuity
+
+To keep the project viable if the maintainer becomes unavailable:
+
+- A GitHub account successor is designated (GitHub Settings → Succession), enabling ownership transfer of the account and repositories.
+- PyPI publishing uses trusted publishing (OIDC) from this repository's release workflow, so no long-lived PyPI token is tied to a personal machine.
+- All project state (code, issues, releases, this documentation) lives in this public repository and can be forked at any time under the MIT license.
+
 ## Decisions
 
 - Day-to-day: decided in GitHub issues/PR discussions.

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,14 @@ pybragerone
    :target: https://www.bestpractices.dev/projects/13994
    :alt: OpenSSF Best Practices
 
+.. image:: https://img.shields.io/badge/OpenSSF%20silver-in%20progress-yellow
+   :target: https://www.bestpractices.dev/en/projects/13994/silver
+   :alt: OpenSSF Best Practices: silver (in progress)
+
+.. image:: https://img.shields.io/badge/OpenSSF%20baseline-in%20progress-yellow
+   :target: https://www.bestpractices.dev/en/projects/13994/baseline-1
+   :alt: OpenSSF Baseline (in progress)
+
 .. image:: https://img.shields.io/github/actions/workflow/status/marpi82/py-bragerone/docs.yml?branch=main&label=docs
    :target: https://github.com/marpi82/py-bragerone/actions/workflows/docs.yml
    :alt: Docs Status


### PR DESCRIPTION
Adds shields for the in-progress OpenSSF silver and baseline levels next to the main best-practices badge (which auto-updates once a level is earned).