### PR TITLE
docs: governance continuity + security assurance case

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,9 @@ pybragerone
    :target: https://www.bestpractices.dev/projects/13994
    :alt: OpenSSF Best Practices
 
-.. image:: https://img.shields.io/badge/OpenSSF%20silver-in%20progress-yellow
-   :target: https://www.bestpractices.dev/en/projects/13994/silver
-   :alt: OpenSSF Best Practices: silver (in progress)
-
-.. image:: https://img.shields.io/badge/OpenSSF%20baseline-in%20progress-yellow
-   :target: https://www.bestpractices.dev/en/projects/13994/baseline-1
-   :alt: OpenSSF Baseline (in progress)
+.. image:: https://www.bestpractices.dev/projects/13994/baseline
+   :target: https://www.bestpractices.dev/projects/13994
+   :alt: OpenSSF Baseline
 
 .. image:: https://img.shields.io/github/actions/workflow/status/marpi82/py-bragerone/docs.yml?branch=main&label=docs
    :target: https://github.com/marpi82/py-bragerone/actions/workflows/docs.yml

--- a/docs/architecture/security.rst
+++ b/docs/architecture/security.rst
@@ -21,7 +21,7 @@ Assets at risk:
 
 Threats considered:
 
-1. *Network attacker (MITM)*) reading or altering API traffic.
+1. *Network attacker (MITM)* reading or altering API traffic.
 2. *Malicious or compromised server responses* (REST snapshots, Socket.IO
    deltas, web-app JS assets) crashing or misleading the client.
 3. *Credential/token leakage* through logs, diagnostics, or the repository.
@@ -45,8 +45,10 @@ Trust boundaries
 Secure design principles applied
 --------------------------------
 
-- **Secure defaults**: TLS certificate verification is always on (httpx
-  defaults, never disabled); tokens auto-refresh without caller involvement.
+- **Secure defaults**: TLS certificate verification is on by default
+  (httpx ``verify=True``); it is never disabled internally — a caller may
+  only weaken it explicitly via the public ``verify`` parameter, e.g. for
+  local diagnostics. Tokens auto-refresh without caller involvement.
 - **Least privilege**: every CI workflow declares minimal ``permissions:``
   (default ``contents: read``); PR-triggered jobs have no access to secrets;
   publishing rights exist only in the tag-triggered release workflow.

--- a/docs/architecture/security.rst
+++ b/docs/architecture/security.rst
@@ -33,14 +33,18 @@ Trust boundaries
 ----------------
 
 1. **Library ↔ BragerOne cloud API** — all data crossing this boundary is
-   untrusted input: REST payloads are validated with pydantic models, and
-   live JS assets are parsed defensively (tree-sitter, no code execution,
-   soft-fail on unexpected shapes).
+   untrusted input: the primary REST DTOs (auth, objects, modules) are
+   validated with pydantic models, while some snapshot/prime endpoints
+   deliberately return raw data for flexibility; live JS assets are always
+   parsed defensively (tree-sitter, no code execution, soft-fail on
+   unexpected shapes).
 2. **Library ↔ host application** (e.g. Home Assistant integration) — the
    public API (``BragerOneApiClient``, ``BragerOneGateway``) is the only
    intended surface; internal modules are not re-exported.
-3. **Repository/CI ↔ PyPI and GitHub Releases** — only the tagged release
-   workflow may publish, via OIDC trusted publishing (no stored PyPI token).
+3. **Repository/CI ↔ package publishing** — PyPI publishes only from the
+   tag-triggered release workflow via OIDC trusted publishing (no stored
+   PyPI token); separately, the docs workflow may deploy GitHub Pages
+   (``pages: write`` scoped to documentation).
 
 Secure design principles applied
 --------------------------------
@@ -51,39 +55,52 @@ Secure design principles applied
   local diagnostics. Tokens auto-refresh without caller involvement.
 - **Least privilege**: every CI workflow declares minimal ``permissions:``
   (default ``contents: read``); PR-triggered jobs have no access to secrets;
-  publishing rights exist only in the tag-triggered release workflow.
+  package-publishing rights exist only in the tag-triggered release
+  workflow.
 - **Fail-safe defaults**: parsers return partial results or ``None`` instead
   of raising on unexpected upstream shapes; a new upstream bundle must not
   crash the library or dependent HA setups.
 - **Economy of mechanism**: the library is a thin async client; protocol
   complexity is isolated in ``api/`` and ``models/`` with a small public API.
-- **Mediation on writes**: the CLI validates every parameter write (enum
-  label→raw conversion, inverse numeric transform, min/max range checks)
-  before dispatch. The low-level ``BragerOneApiClient`` write methods are
-  intentionally a thin raw transport; callers building on them (e.g. the
-  Home Assistant integration) are expected to implement the equivalent
-  validation layer, and the integration does.
+- **Mediation on writes**: the CLI checks numeric writes against the
+  catalog's min/max range and applies the numeric transform before
+  dispatch; nonnumeric values are passed through without range checks, and
+  enum handling is left to callers. The low-level ``BragerOneApiClient``
+  write methods are intentionally a thin raw transport; callers building on
+  them (e.g. the Home Assistant integration) are expected to implement the
+  full validation layer (enum label→raw, inverse transform, range/route
+  checks), and the integration does.
 
 Countering common implementation weaknesses
 --------------------------------------------
 
-- **Injection**: no ``eval``/``exec``, no shell invocation with untrusted
-  data; JavaScript assets are parsed with tree-sitter, never executed.
+- **Injection**: no ``eval``/``exec`` and no shell invocation on untrusted
+  runtime data; JavaScript assets are parsed with tree-sitter, never
+  executed. (One deliberate exception: the Sphinx build ``exec``es a
+  trusted, repo-generated version file in ``docs/conf.py``.)
 - **Secrets exposure**: in-repo controls: gitleaks runs in CI and
-  pre-commit, credentials are sourced from environment/keyring and never
-  stored in the repository, and logs/diagnostics redact credentials. As a
-  hosting-layer control, the GitHub repository additionally has secret
-  scanning with push protection enabled.
+  pre-commit, and nothing sensitive is stored in the repository. The CLI
+  takes account credentials from ``--email``/``--password`` or
+  ``PYBO_EMAIL``/``PYBO_PASSWORD`` environment variables; its token store
+  keeps the resulting access/refresh tokens in the system keyring with a
+  file fallback. Log/diagnostic redaction is available and configurable.
+  As a hosting-layer control, the GitHub repository additionally has
+  secret scanning with push protection enabled.
 - **Broken crypto**: the library implements no cryptography itself; transport
   security is delegated to Python's TLS stack (TLS 1.2+).
-- **Memory safety**: pure Python — no native code is produced or shipped.
+- **Memory safety**: the library itself is pure Python, but it relies on the
+  native ``tree-sitter``/``tree-sitter-javascript`` extensions for asset
+  parsing; that native boundary handles untrusted JS bytes and is exercised
+  by the fuzz harness and property tests.
 - **Vulnerable dependencies**: dependencies are declared in
   ``pyproject.toml`` and pinned in ``uv.lock``; Dependabot and Renovate keep
   them current; pip-audit scans them in CI; security exceptions (if any) are
   documented and tracked in ``SECURITY.md``.
-- **Static/dynamic analysis**: bandit, semgrep and CodeQL run in CI;
-  ``mypy --strict`` and ruff enforce type and code discipline; a fuzz
-  harness (atheris) plus Hypothesis property tests exercise the parsers.
+- **Static/dynamic analysis**: CodeQL and pip-audit run in GitHub Actions;
+  bandit and semgrep run in pre-commit hooks and via the local
+  ``poe security`` task; ``mypy --strict`` and ruff enforce type and code
+  discipline; a fuzz harness (atheris) plus Hypothesis property tests
+  exercise the parsers.
 - **Release integrity**: releases are built in CI from the tagged commit and
   ship with SHA256 checksums, a CycloneDX SBOM, and Sigstore
   build-provenance attestations verifiable with ``gh attestation verify``.

--- a/docs/architecture/security.rst
+++ b/docs/architecture/security.rst
@@ -1,0 +1,91 @@
+Security assurance case
+=======================
+
+This document is the security assurance case for py-bragerone: it justifies
+why the project's security requirements are met. It describes the threat
+model, identifies trust boundaries, argues that secure design principles are
+applied, and shows how common implementation security weaknesses are
+countered.
+
+Threat model
+------------
+
+Assets at risk:
+
+- **User credentials** (BragerOne account email/password) and the resulting
+  **access/refresh tokens**, handled at runtime by the library.
+- **Integrity of parameter writes** sent to heating controllers (a wrong
+  value can change physical heating behavior).
+- **Integrity of the library itself** (supply chain: dependencies, build and
+  release pipeline).
+
+Threats considered:
+
+1. *Network attacker (MITM)*) reading or altering API traffic.
+2. *Malicious or compromised server responses* (REST snapshots, Socket.IO
+   deltas, web-app JS assets) crashing or misleading the client.
+3. *Credential/token leakage* through logs, diagnostics, or the repository.
+4. *Supply-chain attacks* via compromised dependencies or a compromised
+   CI/CD pipeline.
+5. *Tampered release artifacts* (PyPI/GitHub Releases).
+
+Trust boundaries
+----------------
+
+1. **Library ↔ BragerOne cloud API** — all data crossing this boundary is
+   untrusted input: REST payloads are validated with pydantic models, and
+   live JS assets are parsed defensively (tree-sitter, no code execution,
+   soft-fail on unexpected shapes).
+2. **Library ↔ host application** (e.g. Home Assistant integration) — the
+   public API (``BragerOneApiClient``, ``BragerOneGateway``) is the only
+   intended surface; internal modules are not re-exported.
+3. **Repository/CI ↔ PyPI and GitHub Releases** — only the tagged release
+   workflow may publish, via OIDC trusted publishing (no stored PyPI token).
+
+Secure design principles applied
+--------------------------------
+
+- **Secure defaults**: TLS certificate verification is always on (httpx
+  defaults, never disabled); tokens auto-refresh without caller involvement.
+- **Least privilege**: every CI workflow declares minimal ``permissions:``
+  (default ``contents: read``); PR-triggered jobs have no access to secrets;
+  publishing rights exist only in the tag-triggered release workflow.
+- **Fail-safe defaults**: parsers return partial results or ``None`` instead
+  of raising on unexpected upstream shapes; a new upstream bundle must not
+  crash the library or dependent HA setups.
+- **Economy of mechanism**: the library is a thin async client; protocol
+  complexity is isolated in ``api/`` and ``models/`` with a small public API.
+- **Complete mediation on writes**: every parameter write goes through one
+  validated path (enum label→raw conversion, inverse numeric transform,
+  min/max range checks) before dispatch.
+
+Countering common implementation weaknesses
+--------------------------------------------
+
+- **Injection**: no ``eval``/``exec``, no shell invocation with untrusted
+  data; JavaScript assets are parsed with tree-sitter, never executed.
+- **Secrets exposure**: gitleaks runs in CI and pre-commit; GitHub secret
+  scanning with push protection is enabled; credentials are sourced from
+  environment/keyring, never stored in the repository; logs and diagnostics
+  redact credentials.
+- **Broken crypto**: the library implements no cryptography itself; transport
+  security is delegated to Python's TLS stack (TLS 1.2+).
+- **Memory safety**: pure Python — no native code is produced or shipped.
+- **Vulnerable dependencies**: dependencies are declared in
+  ``pyproject.toml`` and pinned in ``uv.lock``; Dependabot and Renovate keep
+  them current; pip-audit scans them in CI; security exceptions (if any) are
+  documented and tracked in ``SECURITY.md``.
+- **Static/dynamic analysis**: bandit, semgrep and CodeQL run in CI;
+  ``mypy --strict`` and ruff enforce type and code discipline; a fuzz
+  harness (atheris) plus Hypothesis property tests exercise the parsers.
+- **Release integrity**: releases are built in CI from the tagged commit and
+  ship with SHA256 checksums, a CycloneDX SBOM, and Sigstore
+  build-provenance attestations verifiable with ``gh attestation verify``.
+
+Residual risk
+-------------
+
+The library depends on the undocumented, evolving BragerOne cloud API and
+web assets; upstream changes can break parsing (mitigated by defensive
+parsing and test coverage) and the service's own security is outside this
+project's control.

--- a/docs/architecture/security.rst
+++ b/docs/architecture/security.rst
@@ -53,12 +53,14 @@ Secure design principles applied
   (httpx ``verify=True``); it is never disabled internally — a caller may
   only weaken it explicitly via the public ``verify`` parameter, e.g. for
   local diagnostics. Tokens auto-refresh without caller involvement.
-- **Least privilege**: every CI workflow declares minimal ``permissions:``
+- **Least privilege**: every workflow declares explicit ``permissions:``
   (default ``contents: read``). PR-triggered jobs have no access to
-  long-lived secrets (there are none stored for CI); they use only the
-  short-lived, workflow-scoped ``GITHUB_TOKEN`` — read-only in CI, and
-  write-scoped solely in the Dependabot auto-label job. Package-publishing
-  rights exist only in the tag-triggered release workflow.
+  long-lived secrets (none are stored for CI); they use only the
+  short-lived, per-run ``GITHUB_TOKEN``. Write scopes are granted narrowly:
+  ``pull-requests: write`` (+ ``contents: write`` only in the Dependabot
+  auto-merge job) and ``security-events: write`` in CodeQL for uploading
+  results. Package-publishing rights exist only in the tag-triggered
+  release workflow.
 - **Fail-safe defaults**: parsers return partial results or ``None`` instead
   of raising on unexpected upstream shapes; a new upstream bundle must not
   crash the library or dependent HA setups.
@@ -82,8 +84,10 @@ Countering common implementation weaknesses
   trusted, repo-generated version file in ``docs/conf.py``.)
 - **Secrets exposure**: in-repo controls: gitleaks runs in CI and
   pre-commit, and nothing sensitive is stored in the repository. The CLI
-  takes account credentials from ``--email``/``--password`` or
-  ``PYBO_EMAIL``/``PYBO_PASSWORD`` environment variables; its token store
+  takes account credentials from ``--email``/``--password`` or the
+  ``PYBO_EMAIL``/``PYBO_PASSWORD`` environment variables (preferred — argv
+  can leak via shell history and process inspection; see Residual risk);
+  its token store
   keeps the resulting access/refresh tokens in the system keyring with a
   file fallback. Log/diagnostic redaction is available and configurable.
   As a hosting-layer control, the GitHub repository additionally has
@@ -117,4 +121,7 @@ web assets; upstream changes can break parsing (mitigated by defensive
 parsing and test coverage) and the service's own security is outside this
 project's control. The native tree-sitter parser boundary is tested with
 malformed-shape fixtures but is not yet covered by the fuzz harness;
-extending fuzzing to that path is tracked as future work.
+extending fuzzing to that path is tracked as future work. The CLI accepts
+a password via ``--password`` argv, which can persist in shell history and
+process listings; prefer the ``PYBO_PASSWORD`` environment variable, and a
+hidden interactive prompt is tracked as a hardening improvement.

--- a/docs/architecture/security.rst
+++ b/docs/architecture/security.rst
@@ -54,9 +54,11 @@ Secure design principles applied
   only weaken it explicitly via the public ``verify`` parameter, e.g. for
   local diagnostics. Tokens auto-refresh without caller involvement.
 - **Least privilege**: every CI workflow declares minimal ``permissions:``
-  (default ``contents: read``); PR-triggered jobs have no access to secrets;
-  package-publishing rights exist only in the tag-triggered release
-  workflow.
+  (default ``contents: read``). PR-triggered jobs have no access to
+  long-lived secrets (there are none stored for CI); they use only the
+  short-lived, workflow-scoped ``GITHUB_TOKEN`` — read-only in CI, and
+  write-scoped solely in the Dependabot auto-label job. Package-publishing
+  rights exist only in the tag-triggered release workflow.
 - **Fail-safe defaults**: parsers return partial results or ``None`` instead
   of raising on unexpected upstream shapes; a new upstream bundle must not
   crash the library or dependent HA setups.
@@ -90,8 +92,10 @@ Countering common implementation weaknesses
   security is delegated to Python's TLS stack (TLS 1.2+).
 - **Memory safety**: the library itself is pure Python, but it relies on the
   native ``tree-sitter``/``tree-sitter-javascript`` extensions for asset
-  parsing; that native boundary handles untrusted JS bytes and is exercised
-  by the fuzz harness and property tests.
+  parsing; that native boundary handles untrusted JS bytes and is covered
+  by the parser-resilience test suite (malformed-shape fixtures). The fuzz
+  harness and property tests currently exercise the other parsers (tokens,
+  permissions, CLI values), not the tree-sitter path — see Residual risk.
 - **Vulnerable dependencies**: dependencies are declared in
   ``pyproject.toml`` and pinned in ``uv.lock``; Dependabot and Renovate keep
   them current; pip-audit scans them in CI; security exceptions (if any) are
@@ -111,4 +115,6 @@ Residual risk
 The library depends on the undocumented, evolving BragerOne cloud API and
 web assets; upstream changes can break parsing (mitigated by defensive
 parsing and test coverage) and the service's own security is outside this
-project's control.
+project's control. The native tree-sitter parser boundary is tested with
+malformed-shape fixtures but is not yet covered by the fuzz harness;
+extending fuzzing to that path is tracked as future work.

--- a/docs/architecture/security.rst
+++ b/docs/architecture/security.rst
@@ -57,19 +57,23 @@ Secure design principles applied
   crash the library or dependent HA setups.
 - **Economy of mechanism**: the library is a thin async client; protocol
   complexity is isolated in ``api/`` and ``models/`` with a small public API.
-- **Complete mediation on writes**: every parameter write goes through one
-  validated path (enum label→raw conversion, inverse numeric transform,
-  min/max range checks) before dispatch.
+- **Mediation on writes**: the CLI validates every parameter write (enum
+  label→raw conversion, inverse numeric transform, min/max range checks)
+  before dispatch. The low-level ``BragerOneApiClient`` write methods are
+  intentionally a thin raw transport; callers building on them (e.g. the
+  Home Assistant integration) are expected to implement the equivalent
+  validation layer, and the integration does.
 
 Countering common implementation weaknesses
 --------------------------------------------
 
 - **Injection**: no ``eval``/``exec``, no shell invocation with untrusted
   data; JavaScript assets are parsed with tree-sitter, never executed.
-- **Secrets exposure**: gitleaks runs in CI and pre-commit; GitHub secret
-  scanning with push protection is enabled; credentials are sourced from
-  environment/keyring, never stored in the repository; logs and diagnostics
-  redact credentials.
+- **Secrets exposure**: in-repo controls: gitleaks runs in CI and
+  pre-commit, credentials are sourced from environment/keyring and never
+  stored in the repository, and logs/diagnostics redact credentials. As a
+  hosting-layer control, the GitHub repository additionally has secret
+  scanning with push protection enabled.
 - **Broken crypto**: the library implements no cryptography itself; transport
   security is delegated to Python's TLS stack (TLS 1.2+).
 - **Memory safety**: pure Python — no native code is produced or shipped.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,4 +115,6 @@ Key Features
    :maxdepth: 1
    :caption: Project
 
+   Governance <https://github.com/marpi82/py-bragerone/blob/main/GOVERNANCE.md>
+   Security policy <https://github.com/marpi82/py-bragerone/blob/main/SECURITY.md>
    GitHub Releases <https://github.com/marpi82/py-bragerone/releases>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,6 +108,7 @@ Key Features
    api/pydantic_models
    architecture/overview
    architecture/operations
+   architecture/security
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
## Summary
- docs/architecture/security.rst: security assurance case (threat model, trust boundaries, secure design principles, weakness countermeasures, residual risk) — evidence for silver `assurance_case`, iteratively aligned with verified code facts through Copilot review
- docs/index.rst: toctree entries for the security page and external links to GOVERNANCE.md / SECURITY.md
- README.rst: official OpenSSF baseline badge next to the metal-series badge

(The GOVERNANCE.md continuity/succession section landed via #252.)

## Test plan
- [x] `sphinx-build -W` clean