### PR TITLE
chore(copilot): flag code↔docs drift in reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -288,3 +288,4 @@ When reviewing pull requests, prioritize (details in `.github/skills/code-review
 4. **Public API stability**: `pybragerone.__all__` (`BragerOneApiClient`, `BragerOneGateway`) and everything documented in `docs/reference/ha_integration.rst` is consumed by the ha-bragerone integration—flag breaking changes.
 5. **Pydantic v2 patterns**: `ConfigDict`, `Field(alias=...)`, `model_validate`; do not introduce v1 idioms.
 6. **Tests**: new behavior needs tests (pytest-httpx for HTTP, `asyncio_mode=auto`); live-API tests must be marked `@pytest.mark.needs_internet`.
+7. **Docs consistency (code↔docs)**: changes to CLI flags/env vars, public API, or any documented behavior must be reflected in `docs/`, `README.rst`, and `examples/`; docs-only changes must match the actual code — flag drift in either direction.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "docs/**,README.rst,examples/**,AGENTS.md"
+---
+
+# Documentation rules
+
+1. **Docs describe the code as it is, not as it should be**: before editing a documented behavior, command, or example, verify it against `src/pybragerone/`. Code changes that alter documented behavior must update the docs in the same PR — drift in either direction is a defect.
+2. **Examples must be runnable**: CLI invocations, env vars, and code snippets in docs/README must work copy-paste; prefer forms that are exercised in tests.
+3. **Version/pin references** (Python, dependencies, HA integration contract) must match `pyproject.toml` and `uv.lock`.
+4. **Sphinx builds with `-W` in CI**: no broken cross-references, every new page added to a toctree.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "docs/**,README.rst,examples/**,AGENTS.md"
+applyTo: "docs/**, README.rst, examples/**, AGENTS.md"
 ---
 
 # Documentation rules

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -55,6 +55,7 @@ Review procedure for pull requests to this library. Work through every section; 
 
 - [ ] Public behavior changes reflected in `docs/` (Sphinx builds with `-W` in CI).
 - [ ] README.rst examples still valid if touched surface is covered there.
+- [ ] **Code↔docs drift (both directions)**: if the PR changes CLI flags/env vars, public API, parameter addressing, or any documented behavior, verify that `docs/**/*.rst`, `README.rst`, and `examples/` still match the code — flag stale claims, commands, or examples. Conversely, for docs-only PRs, spot-check the documented behavior against the actual code in `src/pybragerone/` and flag mismatches.
 
 ## Stack awareness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Parameter addressing: `P<n>.<chan><idx>` (channels: `v` value, `s` status bitmas
 
 ## Docs
 
-Sphinx + Furo; `uv run --group dev --group docs poe docs-build` (poe lives in `dev`). Sphinx runs with `-W` in CI — warnings are errors. Update `docs/` when changing public behavior.
+Sphinx + Furo; `uv run --group dev --group docs poe docs-build` (poe lives in `dev`). Sphinx runs with `-W` in CI — warnings are errors. Update `docs/` when changing public behavior, and treat docs↔code drift in either direction as a defect: docs must describe the code as it is.
 
 ## CI gates (`.github/workflows/ci.yml`)
 


### PR DESCRIPTION
## Summary
- Adds a bidirectional documentation-consistency rule to all Copilot review surfaces: code changes altering documented behavior must update `docs/`, `README.rst`, `examples/` in the same PR; docs-only changes must be verified against the actual code.
- New `.github/instructions/docs.instructions.md` scoped to `docs/**`, `README.rst`, `examples/**`, `AGENTS.md`.
- `AGENTS.md` Docs section now treats docs↔code drift as a defect.

## Test plan
- [ ] Copilot review on this PR surfaces no issues with the new rules