### PR TITLE
fix(ws): self-healing reconnect — connect timeout, fresh token per attempt, unkillable supervisor

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,7 @@ Key Features
    Built on ``httpx`` with automatic token refresh and HTTP caching
 
 ⚡ **Real-time WebSocket**
-   Socket.IO client with automatic reconnection and event streaming
+   Socket.IO client with supervised automatic reconnection and event streaming
 
 📊 **ParamStore**
    Runtime-light storage for live values (use **ParamResolver** for asset-driven discovery/metadata)

--- a/src/pybragerone/api/ws.py
+++ b/src/pybragerone/api/ws.py
@@ -76,6 +76,8 @@ class RealtimeManager:
         io_base: str = IO_BASE,
         socket_path: str = SOCK_PATH,
         namespace: str = WS_NAMESPACE,
+        token_provider: Callable[[], Awaitable[str]] | None = None,
+        connect_timeout_s: float = 20.0,
     ) -> None:
         """Initialize the realtime manager.
 
@@ -86,8 +88,15 @@ class RealtimeManager:
             io_base: Base URL of the Engine.IO/Socket.IO server (default: :data:`~.constants.IO_BASE`).
             socket_path: Socket.IO path on the server (default: :data:`~.constants.SOCK_PATH`).
             namespace: The namespace to join (default: :data:`~.constants.WS_NAMESPACE`).
+            token_provider: Optional async callable returning a fresh Bearer token. When set, every
+                (re)connect attempt resolves the token through it, so long outages that outlive the
+                token TTL can still recover. Falls back to the static ``token`` when unset or on error.
+            connect_timeout_s: Maximum seconds a single connect attempt may take before it is aborted
+                and retried by the supervisor (default: 20). Guards against hung TCP/DNS handshakes.
         """
         self._token = token
+        self._token_provider = token_provider
+        self._connect_timeout_s = connect_timeout_s
         self._origin = origin
         self._referer = referer
         self._io_base = io_base.rstrip("/")
@@ -277,26 +286,44 @@ class RealtimeManager:
 
         task.add_done_callback(_supervisor_done)
 
+    async def _resolve_token(self) -> str:
+        """Return a token for the next connect attempt, refreshing via the provider if set."""
+        if self._token_provider is None:
+            return self._token
+        try:
+            token = await self._token_provider()
+        except Exception:
+            # Auth backend unreachable (e.g. same outage as the WS) — retry with the last known token.
+            log.warning("WS token refresh failed; falling back to the previous token", exc_info=True)
+            return self._token
+        self._token = token
+        return token
+
     async def _ensure_connected(self, *, initial: bool) -> None:
         if self._sio.connected and self._connected.is_set():
             return
         async with self._connect_lock:
             if self._sio.connected and self._connected.is_set():
                 return
+            token = await self._resolve_token()
             headers = {
-                "Authorization": f"Bearer {self._token}",
+                "Authorization": f"Bearer {token}",
                 "Origin": self._origin,
                 "Referer": self._referer,
                 "Accept-Language": "pl-PL,pl;q=0.9",
                 "x-appversion": "1.1.78",
             }
             try:
-                await self._sio.connect(
-                    self._io_base,
-                    headers=headers,
-                    transports=["pooling", "websocket"],
-                    socketio_path=self._socket_path,
-                    namespaces=[self._namespace],
+                # Hard timeout: a hung TCP/DNS handshake must not wedge the supervisor forever.
+                await asyncio.wait_for(
+                    self._sio.connect(
+                        self._io_base,
+                        headers=headers,
+                        transports=["pooling", "websocket"],
+                        socketio_path=self._socket_path,
+                        namespaces=[self._namespace],
+                    ),
+                    timeout=self._connect_timeout_s,
                 )
             except Exception:
                 self._connected.clear()
@@ -311,7 +338,11 @@ class RealtimeManager:
                 if self._sio.connected and self._connected.is_set():
                     continue
                 log.warning("WS disconnected state detected; forcing reconnect")
-                await self._ensure_connected(initial=False)
+                try:
+                    await self._ensure_connected(initial=False)
+                except Exception:
+                    # Defensive: the supervisor must never die on an unexpected error.
+                    log.exception("WS supervisor iteration failed unexpectedly")
         except asyncio.CancelledError:
             raise
 

--- a/src/pybragerone/api/ws.py
+++ b/src/pybragerone/api/ws.py
@@ -88,9 +88,11 @@ class RealtimeManager:
             io_base: Base URL of the Engine.IO/Socket.IO server (default: :data:`~.constants.IO_BASE`).
             socket_path: Socket.IO path on the server (default: :data:`~.constants.SOCK_PATH`).
             namespace: The namespace to join (default: :data:`~.constants.WS_NAMESPACE`).
-            token_provider: Optional async callable returning a fresh Bearer token. When set, every
-                (re)connect attempt resolves the token through it, so long outages that outlive the
-                token TTL can still recover. Falls back to the static ``token`` when unset or on error.
+            token_provider: Optional async callable returning a fresh access token (the
+                ``Bearer `` prefix is added by the manager). When set, every (re)connect
+                attempt resolves the token through it, so long outages that outlive the
+                token TTL can still recover. Falls back to the static ``token`` when unset
+                or on error.
             connect_timeout_s: Maximum seconds a single connect attempt may take before it is aborted
                 and retried by the supervisor (default: 20). Guards against hung TCP/DNS handshakes.
         """

--- a/src/pybragerone/api/ws.py
+++ b/src/pybragerone/api/ws.py
@@ -292,9 +292,11 @@ class RealtimeManager:
         if self._token_provider is None:
             return self._token
         try:
-            token = await self._token_provider()
+            # Bound the provider too: re-authentication can stall during the same
+            # outage, and it must not wedge the supervisor before connect() even runs.
+            token = await asyncio.wait_for(self._token_provider(), timeout=self._connect_timeout_s)
         except Exception:
-            # Auth backend unreachable (e.g. same outage as the WS) — retry with the last known token.
+            # Auth backend unreachable or stalled — retry with the last known token.
             log.warning("WS token refresh failed; falling back to the previous token", exc_info=True)
             return self._token
         self._token = token

--- a/src/pybragerone/api/ws.py
+++ b/src/pybragerone/api/ws.py
@@ -115,12 +115,11 @@ class RealtimeManager:
         self._supervisor_running = False
         self._supervisor_interval_s = 15.0
 
-        # Configure AsyncClient with reconnection enabled.
+        # Reconnection is owned exclusively by our supervisor loop (with fresh-token
+        # resolution and a hard connect timeout); the built-in socket.io reconnect
+        # loop would bypass both and race with the supervisor, so it stays disabled.
         self._sio: socketio.AsyncClient = socketio.AsyncClient(
-            reconnection=True,
-            reconnection_attempts=0,  # infinite
-            reconnection_delay=1,
-            reconnection_delay_max=10,
+            reconnection=False,
             logger=sio_log,  # pyright: ignore[reportArgumentType] # route socket.io logs to a sub-logger
             engineio_logger=eio_log,  # route engine.io logs to a sub-logger
         )

--- a/src/pybragerone/cli.py
+++ b/src/pybragerone/cli.py
@@ -538,7 +538,9 @@ async def run(args: argparse.Namespace) -> int:
 
     # Temporary REST client for object/modules selection
     server = server_for(args.platform)
-    api = BragerOneApiClient(server=server)
+    # creds_provider lets the client re-login when the token expires mid-session
+    # (e.g. WS reconnect after a long outage).
+    api = BragerOneApiClient(server=server, creds_provider=lambda: (args.email, args.password))
     api.set_token_store(store)
 
     gw: BragerOneGateway | None = None

--- a/src/pybragerone/gateway.py
+++ b/src/pybragerone/gateway.py
@@ -165,7 +165,12 @@ class BragerOneGateway:
             An initialized gateway (not started).
         """
         owned_api = api is None
-        api_client = api or BragerOneApiClient(server=server)
+        api_client = api or BragerOneApiClient(
+            server=server,
+            # Retain credentials so ensure_auth() can re-login when the token
+            # expires mid-session (e.g. WS reconnect after a long outage).
+            creds_provider=lambda: (email, password),
+        )
         await api_client.ensure_auth(email, password)
         return cls(api=api_client, object_id=object_id, modules=modules, ws=ws, owns_api=owned_api)
 

--- a/src/pybragerone/gateway.py
+++ b/src/pybragerone/gateway.py
@@ -195,6 +195,7 @@ class BragerOneGateway:
             if isinstance(self.api, BragerOneApiClient):
                 self.ws = RealtimeManager(
                     token=self.api.access_token,
+                    token_provider=self._fresh_ws_token,
                     origin=self.api.one_base,
                     referer=f"{self.api.one_base}/",
                     io_base=self.api.io_base,
@@ -275,6 +276,14 @@ class BragerOneGateway:
     async def __aexit__(self, *exc: Any) -> None:
         """Async context manager exit."""
         await self.stop()
+
+    async def _fresh_ws_token(self) -> str:
+        """Return a valid token for a WS (re)connect, re-authenticating if expired."""
+        api = self.api
+        if not isinstance(api, BragerOneApiClient):
+            return api.access_token
+        await api.ensure_auth()
+        return api.access_token
 
     async def resubscribe(self) -> None:
         """Call after WS reconnect to re-bind modules + prime again."""

--- a/tests/test_gateway_prime_reconnect.py
+++ b/tests/test_gateway_prime_reconnect.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 import pytest
+from pytest_httpx import HTTPXMock
 
+from pybragerone.api import BragerOneApiClient
 from pybragerone.gateway import BragerOneGateway
+from pybragerone.models import Token
 from pybragerone.models.events import ParamUpdate
+
+API = "https://io.brager.pl"
+TEST_EMAIL = "a@b"
+TEST_PASSWORD = "pw"
 
 
 class FakeApiClient:
@@ -171,3 +179,47 @@ async def test_gateway_resubscribe_on_connected_reprimes() -> None:
     assert api._prime_activity_calls == [["M1"], ["M1"]]
 
     await gw.stop()
+
+
+async def test_start_wires_self_healing_token_provider(monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock) -> None:
+    """A gateway-created RealtimeManager gets a token provider that re-logins after token expiry."""
+    api = BragerOneApiClient(creds_provider=lambda: (TEST_EMAIL, TEST_PASSWORD))
+    # Simulate a long-running session whose token expired during an outage.
+    api._token = Token(access_token="EXPIRED", expires_at=datetime.now(UTC) - timedelta(hours=1))
+
+    captured: dict[str, Any] = {}
+
+    def _fake_rm(**kwargs: Any) -> FakeRealtimeManager:
+        captured.update(kwargs)
+        return FakeRealtimeManager()
+
+    monkeypatch.setattr("pybragerone.gateway.RealtimeManager", _fake_rm)
+    # The wiring under test is WS construction; stub the REST prime calls on the real client.
+    monkeypatch.setattr(api, "modules_connect", lambda *a, **k: _async_true())
+    monkeypatch.setattr(api, "modules_parameters_prime", lambda *a, **k: _async_true())
+    monkeypatch.setattr(api, "modules_activity_quantity_prime", lambda *a, **k: _async_true())
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{API}/v1/auth/user",
+        json={
+            "accessToken": "FRESH",
+            "refreshToken": "R2",
+            "type": "bearer",
+            "expiresAt": (datetime.now(UTC) + timedelta(minutes=10)).isoformat(),
+        },
+    )
+
+    gw = BragerOneGateway(api=api, object_id=1, modules=["M1"])
+    await gw.start()
+
+    provider = captured.get("token_provider")
+    assert provider is not None, "gateway must wire a token provider into RealtimeManager"
+    assert await provider() == "FRESH"
+    assert api.access_token == "FRESH"
+
+    await gw.stop()
+
+
+async def _async_true() -> bool:
+    return True

--- a/tests/test_ws_self_heal.py
+++ b/tests/test_ws_self_heal.py
@@ -175,29 +175,31 @@ async def test_token_provider_failure_falls_back_to_static_token(monkeypatch: py
 
 
 async def test_supervisor_survives_unexpected_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An unexpected exception in a reconnect attempt must not kill the supervisor task."""
+    """An exception escaping _ensure_connected must not kill the supervisor task."""
     fake = FakeAsyncClient()
-    second_attempt = asyncio.Event()
-
-    async def _boom(*args: Any, **kwargs: Any) -> None:
-        fake.connect_calls += 1
-        if fake.connect_calls >= 3:  # initial + one retry = supervisor alive
-            second_attempt.set()
-        raise RuntimeError("unexpected")
-
-    # method-assign: the fake must raise on every connect; FakeAsyncClient has no failure hook
-    fake.connect = _boom  # type: ignore[method-assign]
     monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
 
     manager = RealtimeManager(token="tkn", connect_timeout_s=0.05)
     manager._supervisor_interval_s = 0.01
 
-    # Initial connect raises; start the supervisor directly for this unit test.
-    with pytest.raises(RuntimeError, match="unexpected"):
-        await manager._ensure_connected(initial=True)
+    # Force the disconnected path, then make _ensure_connected itself blow up —
+    # this bypasses its internal except-Exception and hits the supervisor guard.
+    attempts = 0
+    survived = asyncio.Event()
+
+    async def _exploding(*args: Any, **kwargs: Any) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts >= 2:
+            survived.set()  # second iteration means the guard caught the first explosion
+        raise RuntimeError("guard me")
+
+    # method-assign: the guard is only exercised when _ensure_connected itself raises
+    manager._ensure_connected = _exploding  # type: ignore[method-assign]
+
     manager._start_supervisor()
 
-    await asyncio.wait_for(second_attempt.wait(), timeout=1.0)
+    await asyncio.wait_for(survived.wait(), timeout=1.0)
     assert manager._supervisor_task is not None and not manager._supervisor_task.done()
 
     await manager.disconnect()

--- a/tests/test_ws_self_heal.py
+++ b/tests/test_ws_self_heal.py
@@ -51,7 +51,6 @@ class FakeAsyncClient:
         return f"NS-{namespace}"
 
 
-@pytest.mark.asyncio
 async def test_realtime_manager_forces_reconnect_when_disconnected(monkeypatch: pytest.MonkeyPatch) -> None:
     """Supervisor should reconnect if client remains disconnected."""
     fake = FakeAsyncClient()
@@ -76,20 +75,24 @@ class HangingAsyncClient(FakeAsyncClient):
     """Fake whose connect hangs forever once `hang` is set (simulates stuck DNS/TCP)."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize with a hang flag."""
+        """Initialize with a hang flag and an event to synchronize on hang attempts."""
         super().__init__(*args, **kwargs)
         self.hang = False
+        self.hang_calls = 0
+        self.third_hang = asyncio.Event()
 
     async def connect(self, *args: Any, **kwargs: Any) -> None:
         """Hang indefinitely when the hang flag is set."""
         if self.hang:
             self.connect_calls += 1
+            self.hang_calls += 1
+            if self.hang_calls >= 3:
+                self.third_hang.set()
             await asyncio.Event().wait()  # never returns
         else:
             await super().connect(*args, **kwargs)
 
 
-@pytest.mark.asyncio
 async def test_supervisor_survives_hung_connect(monkeypatch: pytest.MonkeyPatch) -> None:
     """A hung connect attempt must be aborted by the timeout and retried, not wedge the supervisor."""
     fake = HangingAsyncClient()
@@ -106,14 +109,12 @@ async def test_supervisor_survives_hung_connect(monkeypatch: pytest.MonkeyPatch)
     await manager._on_disconnect()
 
     # The supervisor must keep timing out and retrying instead of hanging inside connect().
-    await asyncio.sleep(0.5)
-    assert fake.connect_calls >= 3
+    await asyncio.wait_for(fake.third_hang.wait(), timeout=1.0)
     assert manager._supervisor_task is not None and not manager._supervisor_task.done()
 
     await manager.disconnect()
 
 
-@pytest.mark.asyncio
 async def test_reconnect_uses_fresh_token_from_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     """Each connect attempt resolves the token via the provider, so expired tokens recover."""
     fake = FakeAsyncClient()
@@ -123,6 +124,7 @@ async def test_reconnect_uses_fresh_token_from_provider(monkeypatch: pytest.Monk
         captured.append(kwargs["headers"]["Authorization"])
         await FakeAsyncClient.connect(fake, *args, **kwargs)
 
+    # method-assign: the fake instance needs per-call header capture; FakeAsyncClient has no hook for it
     fake.connect = _connect  # type: ignore[method-assign]
     monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
 
@@ -148,7 +150,6 @@ async def test_reconnect_uses_fresh_token_from_provider(monkeypatch: pytest.Monk
     await manager.disconnect()
 
 
-@pytest.mark.asyncio
 async def test_token_provider_failure_falls_back_to_static_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """If the provider raises (auth backend down), the attempt still uses the last known token."""
     fake = FakeAsyncClient()
@@ -158,6 +159,7 @@ async def test_token_provider_failure_falls_back_to_static_token(monkeypatch: py
         captured.append(kwargs["headers"]["Authorization"])
         await FakeAsyncClient.connect(fake, *args, **kwargs)
 
+    # method-assign: the fake instance needs per-call header capture; FakeAsyncClient has no hook for it
     fake.connect = _connect  # type: ignore[method-assign]
     monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
 
@@ -172,15 +174,18 @@ async def test_token_provider_failure_falls_back_to_static_token(monkeypatch: py
     await manager.disconnect()
 
 
-@pytest.mark.asyncio
 async def test_supervisor_survives_unexpected_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """An unexpected exception in a reconnect attempt must not kill the supervisor task."""
     fake = FakeAsyncClient()
+    second_attempt = asyncio.Event()
 
     async def _boom(*args: Any, **kwargs: Any) -> None:
         fake.connect_calls += 1
+        if fake.connect_calls >= 3:  # initial + one retry = supervisor alive
+            second_attempt.set()
         raise RuntimeError("unexpected")
 
+    # method-assign: the fake must raise on every connect; FakeAsyncClient has no failure hook
     fake.connect = _boom  # type: ignore[method-assign]
     monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
 
@@ -192,8 +197,7 @@ async def test_supervisor_survives_unexpected_errors(monkeypatch: pytest.MonkeyP
         await manager._ensure_connected(initial=True)
     manager._start_supervisor()
 
-    await asyncio.sleep(0.2)
-    assert fake.connect_calls >= 2
+    await asyncio.wait_for(second_attempt.wait(), timeout=1.0)
     assert manager._supervisor_task is not None and not manager._supervisor_task.done()
 
     await manager.disconnect()

--- a/tests/test_ws_self_heal.py
+++ b/tests/test_ws_self_heal.py
@@ -70,3 +70,130 @@ async def test_realtime_manager_forces_reconnect_when_disconnected(monkeypatch: 
     assert fake.connect_calls >= 2
 
     await manager.disconnect()
+
+
+class HangingAsyncClient(FakeAsyncClient):
+    """Fake whose connect hangs forever once `hang` is set (simulates stuck DNS/TCP)."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize with a hang flag."""
+        super().__init__(*args, **kwargs)
+        self.hang = False
+
+    async def connect(self, *args: Any, **kwargs: Any) -> None:
+        """Hang indefinitely when the hang flag is set."""
+        if self.hang:
+            self.connect_calls += 1
+            await asyncio.Event().wait()  # never returns
+        else:
+            await super().connect(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_supervisor_survives_hung_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hung connect attempt must be aborted by the timeout and retried, not wedge the supervisor."""
+    fake = HangingAsyncClient()
+    monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
+
+    manager = RealtimeManager(token="tkn", connect_timeout_s=0.05)
+    manager._supervisor_interval_s = 0.01
+
+    await manager.connect()
+    assert fake.connect_calls == 1
+
+    fake.hang = True
+    fake.connected = False
+    await manager._on_disconnect()
+
+    # The supervisor must keep timing out and retrying instead of hanging inside connect().
+    await asyncio.sleep(0.5)
+    assert fake.connect_calls >= 3
+    assert manager._supervisor_task is not None and not manager._supervisor_task.done()
+
+    await manager.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_uses_fresh_token_from_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each connect attempt resolves the token via the provider, so expired tokens recover."""
+    fake = FakeAsyncClient()
+    captured: list[str] = []
+
+    async def _connect(*args: Any, **kwargs: Any) -> None:
+        captured.append(kwargs["headers"]["Authorization"])
+        await FakeAsyncClient.connect(fake, *args, **kwargs)
+
+    fake.connect = _connect  # type: ignore[method-assign]
+    monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
+
+    counter = 0
+
+    async def _provider() -> str:
+        nonlocal counter
+        counter += 1
+        return f"fresh-{counter}"
+
+    manager = RealtimeManager(token="stale", token_provider=_provider, connect_timeout_s=0.05)
+    manager._supervisor_interval_s = 0.01
+
+    await manager.connect()
+    fake.connected = False
+    await manager._on_disconnect()
+    await asyncio.wait_for(fake.reconnect_event.wait(), timeout=1.0)
+
+    assert captured[0] == "Bearer fresh-1"
+    assert captured[-1] != "Bearer stale"
+    assert counter >= 2
+
+    await manager.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_token_provider_failure_falls_back_to_static_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the provider raises (auth backend down), the attempt still uses the last known token."""
+    fake = FakeAsyncClient()
+    captured: list[str] = []
+
+    async def _connect(*args: Any, **kwargs: Any) -> None:
+        captured.append(kwargs["headers"]["Authorization"])
+        await FakeAsyncClient.connect(fake, *args, **kwargs)
+
+    fake.connect = _connect  # type: ignore[method-assign]
+    monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
+
+    async def _failing() -> str:
+        raise RuntimeError("auth backend unreachable")
+
+    manager = RealtimeManager(token="last-known", token_provider=_failing, connect_timeout_s=0.05)
+    await manager.connect()
+
+    assert captured[0] == "Bearer last-known"
+
+    await manager.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_supervisor_survives_unexpected_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unexpected exception in a reconnect attempt must not kill the supervisor task."""
+    fake = FakeAsyncClient()
+
+    async def _boom(*args: Any, **kwargs: Any) -> None:
+        fake.connect_calls += 1
+        raise RuntimeError("unexpected")
+
+    fake.connect = _boom  # type: ignore[method-assign]
+    monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
+
+    manager = RealtimeManager(token="tkn", connect_timeout_s=0.05)
+    manager._supervisor_interval_s = 0.01
+
+    # Initial connect raises; start the supervisor directly for this unit test.
+    with pytest.raises(RuntimeError, match="unexpected"):
+        await manager._ensure_connected(initial=True)
+    manager._start_supervisor()
+
+    await asyncio.sleep(0.2)
+    assert fake.connect_calls >= 2
+    assert manager._supervisor_task is not None and not manager._supervisor_task.done()
+
+    await manager.disconnect()

--- a/tests/test_ws_self_heal.py
+++ b/tests/test_ws_self_heal.py
@@ -203,3 +203,28 @@ async def test_supervisor_survives_unexpected_errors(monkeypatch: pytest.MonkeyP
     assert manager._supervisor_task is not None and not manager._supervisor_task.done()
 
     await manager.disconnect()
+
+
+async def test_hanging_token_provider_falls_back_to_static_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stalled token provider must not wedge the supervisor — fall back to the last known token."""
+    fake = FakeAsyncClient()
+    captured: list[str] = []
+
+    async def _connect(*args: Any, **kwargs: Any) -> None:
+        captured.append(kwargs["headers"]["Authorization"])
+        await FakeAsyncClient.connect(fake, *args, **kwargs)
+
+    # method-assign: the fake instance needs per-call header capture; FakeAsyncClient has no hook for it
+    fake.connect = _connect  # type: ignore[method-assign]
+    monkeypatch.setattr("pybragerone.api.ws.socketio.AsyncClient", lambda **kwargs: fake)
+
+    async def _hanging() -> str:
+        await asyncio.Event().wait()  # never returns
+        return "unreachable"
+
+    manager = RealtimeManager(token="last-known", token_provider=_hanging, connect_timeout_s=0.05)
+    await asyncio.wait_for(manager.connect(), timeout=1.0)
+
+    assert captured[0] == "Bearer last-known"
+
+    await manager.disconnect()


### PR DESCRIPTION
## Summary
Diagnosed from a production HA log: a multi-day DNS outage killed the WS connection **permanently** — last "forcing reconnect" at 04:19, then 16h of silence until HA restart. Three compounding defects fixed:

1. **Hung connect wedged the supervisor**: `_ensure_connected` had no timeout; a stuck TCP/DNS handshake blocked the supervisor task forever. Connect attempts are now wrapped in `asyncio.wait_for` (default 20s, configurable via `connect_timeout_s`).
2. **Stale token after long outages**: the WS `Authorization` header used the startup token snapshot, so once the token TTL elapsed every reconnect was rejected even with the network back. `RealtimeManager` accepts an async `token_provider`, resolved fresh on every attempt (falls back to the last known token if refresh fails); the gateway wires it to `ensure_auth()`, which transparently re-logins when credentials are available.
3. **Supervisor could die on unexpected errors**: the loop body is now guarded (`LOG.exception` + continue); only cancellation stops it.

Also: CLI passes `creds_provider` so its client can re-login mid-session.

fixes #141 

## Test plan
- [x] New regression tests: hung connect aborted & retried; fresh token per attempt; provider failure fallback; supervisor survives unexpected exceptions
- [x] Full pytest suite green, mypy --strict green
- [x] Follow-up in ha-bragerone: pass `creds_provider` from the config entry + bump the `py-bragerone` pin after release