### PR TITLE
fix(release): keep dist/ PyPI-pure, move release assets aside

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,15 +61,16 @@ jobs:
       - name: Generate SHA256 checksums
         shell: bash
         run: |
+          mkdir -p release-assets
           cd dist
-          sha256sum *.whl *.tar.gz > SHA256SUMS
+          sha256sum *.whl *.tar.gz > ../release-assets/SHA256SUMS
 
       - name: Generate SBOM (CycloneDX)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: ./
           format: cyclonedx-json
-          output-file: dist/sbom.cyclonedx.json
+          output-file: release-assets/sbom.cyclonedx.json
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -85,7 +86,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
-          path: dist/*
+          path: |
+            dist/*
+            release-assets/*
 
       - name: Publish to TestPyPI (pre-release tag)
         if: ${{ steps.meta.outputs.prerelease == 'true' }}
@@ -104,5 +107,5 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/SHA256SUMS
-            dist/sbom.cyclonedx.json
+            release-assets/SHA256SUMS
+            release-assets/sbom.cyclonedx.json


### PR DESCRIPTION
## Summary
- The 2026.8.2 release failed at PyPI publish: twine (run by gh-action-pypi-publish over `dist/*`) rejects `SHA256SUMS` and `sbom.cyclonedx.json` as unknown distribution formats.
- Checksums and SBOM move to `release-assets/`; `dist/` stays wheel+sdist only (also guarded by the earlier `twine check dist/*` step).
- GitHub Release asset filenames are unchanged, so docs remain accurate.

## Test plan
- [ ] After merge: re-tag 2026.8.2 on main and confirm the release workflow publishes to PyPI and creates the GitHub Release with all four assets.